### PR TITLE
Ignore metric weights in layers

### DIFF
--- a/larq/layers.py
+++ b/larq/layers.py
@@ -56,6 +56,14 @@ class QuantizerBase(tf.keras.layers.Layer):
                     values_shape=self.kernel.shape, name=f"{self.name}/flip_ratio"
                 )
 
+    @property
+    def non_trainable_weights(self):
+        weights = super().non_trainable_weights
+        if hasattr(self, "flip_ratio"):
+            metrics_weights = self.flip_ratio.weights
+            return [weight for weight in weights if weight not in metrics_weights]
+        return weights
+
     def call(self, inputs):
         if self.input_quantizer:
             inputs = self.input_quantizer(inputs)
@@ -115,6 +123,14 @@ class QuantizerDepthwiseBase(tf.keras.layers.Layer):
                     values_shape=self.depthwise_kernel.shape,
                     name=f"{self.name}/flip_ratio",
                 )
+
+    @property
+    def non_trainable_weights(self):
+        weights = super().non_trainable_weights
+        if hasattr(self, "flip_ratio"):
+            metrics_weights = self.flip_ratio.weights
+            return [weight for weight in weights if weight not in metrics_weights]
+        return weights
 
     def call(self, inputs):
         if self.input_quantizer:
@@ -198,6 +214,18 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
                     values_shape=self.pointwise_kernel.shape,
                     name=f"{self.name}/pointwise_flip_ratio",
                 )
+
+    @property
+    def non_trainable_weights(self):
+        weights = super().non_trainable_weights
+        metrics_weights = []
+        if hasattr(self, "depthwise_flip_ratio"):
+            metrics_weights.extend(self.depthwise_flip_ratio.weights)
+        if hasattr(self, "pointwise_flip_ratio"):
+            metrics_weights.extend(self.pointwise_flip_ratio.weights)
+        if metrics_weights:
+            return [weight for weight in weights if weight not in metrics_weights]
+        return weights
 
     def call(self, inputs):
         if self.input_quantizer:

--- a/larq/models.py
+++ b/larq/models.py
@@ -24,17 +24,16 @@ class SummaryTable(AsciiTable):
         self.inner_heading_row_border = False
 
 
-def _count_params(weights, ignore=[]):
+def _count_params(weights):
     """Count the total number of scalars composing the weights.
 
     # Arguments
     weights: An iterable containing the weights on which to compute params
-    ignore: A list of weights to ignore
 
     # Returns
     The total number of scalars composing the weights
     """
-    return int(sum(np.prod(w.shape.as_list()) for w in weights if w not in ignore))
+    return int(sum(np.prod(w.shape.as_list()) for w in weights))
 
 
 def _get_output_shape(layer):
@@ -51,17 +50,16 @@ def _compute_memory(layer_stat):
     return _bit_to_kB(mem_in_bits)
 
 
-def _parse_params(layer, ignore=[]):
+def _parse_params(layer):
     if hasattr(layer, "quantized_latent_weights"):
         params = {}
         for quantizer, weight in zip(layer.quantizers, layer.quantized_latent_weights):
-            if weight not in ignore:
-                precision = getattr(quantizer, "precision", 32)
-                params[precision] = params.get(precision, 0) + int(
-                    np.prod(weight.shape.as_list())
-                )
+            precision = getattr(quantizer, "precision", 32)
+            params[precision] = params.get(precision, 0) + int(
+                np.prod(weight.shape.as_list())
+            )
         for weight in layer.weights:
-            if weight not in layer.quantized_latent_weights and weight not in ignore:
+            if weight not in layer.quantized_latent_weights:
                 params[32] = params.get(32, 0) + int(np.prod(weight.shape.as_list()))
         return params
     return {32: layer.count_params()}
@@ -86,8 +84,8 @@ def _get_input_precision(layer):
         return "-"
 
 
-def _generate_table(model, ignore=[]):
-    layer_stats = [_parse_params(l, ignore=ignore) for l in model.layers]
+def _generate_table(model):
+    layer_stats = [_parse_params(l) for l in model.layers]
     summed_stat = _sum_params(layer_stats)
 
     table = [
@@ -144,19 +142,14 @@ def summary(model, print_fn=None):
             "`input_shape` argument in the first layer(s) for automatic build."
         )
 
-    metrics_weights = [weight for metric in model.metrics for weight in metric.weights]
-    table = _generate_table(model, ignore=metrics_weights)
+    table = _generate_table(model)
 
     model._check_trainable_weights_consistency()
     if hasattr(model, "_collected_trainable_weights"):
-        trainable_count = _count_params(
-            model._collected_trainable_weights, ignore=metrics_weights
-        )
+        trainable_count = _count_params(model._collected_trainable_weights)
     else:
-        trainable_count = _count_params(model.trainable_weights, ignore=metrics_weights)
-    non_trainable_count = _count_params(
-        model.non_trainable_weights, ignore=metrics_weights
-    )
+        trainable_count = _count_params(model.trainable_weights)
+    non_trainable_count = _count_params(model.non_trainable_weights)
 
     if print_fn is None:
         print_fn = print


### PR DESCRIPTION
This will ignore the weights added by metrics when calling `layer.weights`. This has a few benefits:
- Weights from layer metrics will not be saved when calling `model`. This means that:
  - checkpoints are compatible between different versions of `larq` and when disabling metrics on the user side. I discovered this when trying to reload an old weights file in `larq-zoo` that didn't include the metrics.
  - checkpoints are smaller since they don't include unnecessary items
- We don't need to handle the ignoring in the `model.summary` code (which is already quite bloated)
- In general interacting with `layer.weights` will be easier since weights related to metrics are hidden for users