### PR TITLE
Fetch larq-zoo docs before running mkdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 junit
 docs/api
+docs/models
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,21 +36,20 @@ pytest .
 Installs dependencies for building the docs:
 
 ```shell
-pip install git+https://github.com/lgeiger/pydoc-markdown.git
+pip install nbconvert git+https://github.com/lgeiger/pydoc-markdown.git
 pip install -e .[docs]
 ```
 
 Inside the project directory run:
 
 ```shell
-python generate_api_docs.py
-mkdocs serve
+./larqdocs.sh serve
 ```
 
 To publish a new version to github pages run:
 
 ```shell
-mkdocs gh-deploy --force
+./larqdocs.sh gh-deploy --force
 ```
 
 ## Code style

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,8 +59,6 @@ jobs:
         displayName: "Install docs dependencies"
         condition: eq(variables['coverage'], 'true')
 
-      - script: |
-          python generate_api_docs.py
-          mkdocs build
+      - script: ./larqdocs.sh build
         displayName: "Build docs"
         condition: eq(variables['coverage'], 'true')

--- a/larqdocs.sh
+++ b/larqdocs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+basedir=`dirname $0`
+
+# Clean generated output
+rm -r $basedir/docs/models || true
+rm -r $basedir/docs/api || true
+
+mkdir $basedir/docs/models
+
+# Generad API docs
+python $basedir/generate_api_docs.py
+
+# Fetch larq-zoo docs
+curl -o $basedir/docs/models/index.md https://raw.githubusercontent.com/larq/zoo/master/docs/index.md
+curl -o $basedir/docs/models/examples.md https://raw.githubusercontent.com/larq/zoo/master/docs/examples.md
+curl -o $basedir/docs/models/api.md https://raw.githubusercontent.com/larq/zoo/master/docs/api.md
+
+# run mkdocs
+mkdocs $1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,10 @@ nav:
       - Optimizers: api/optimizers.md
       - Math: api/math.md
       - Models: api/models.md
+  - Models:
+      - Larq Zoo: models/index.md
+      - Examples: models/examples.md
+      - API: models/api.md
   - Community:
       - Papers using Larq: papers.md
       - Contributing Guide: contributing.md


### PR DESCRIPTION
This will add a Model tab on our site, that will include the docs for `larq-zoo`