### PR TITLE
Correct inequality sign in SteTern documentation

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -137,7 +137,7 @@ class SteTern:
     q(x) = \begin{cases}
     +1 & x > \Delta \\\
     0 & |x| < \Delta \\\
-    -1 & x < \Delta
+     -1 & x < - \Delta
     \end{cases}
     \\]
 

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -136,7 +136,7 @@ class SteTern:
     \\[
     q(x) = \begin{cases}
     +1 & x > \Delta \\\
-    0 & |x| > \Delta \\\
+    0 & |x| < \Delta \\\
     -1 & x < \Delta
     \end{cases}
     \\]


### PR DESCRIPTION
Changed previously wrong direction of one inequality symbol in SteTern documentation