### PR TITLE
Add pyflakes and black linting

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,3 +46,21 @@ jobs:
       - script: ./larqdocs.sh build
         displayName: "Build docs"
         condition: eq(variables['docs'], 'true')
+
+  - job: "Lint"
+    pool:
+      vmImage: "Ubuntu-16.04"
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.7"
+          architecture: "x64"
+
+      - script: pip install pyflakes==2.1.1 black==19.3b0
+        displayName: "Install linting dependencies"
+
+      - script: pyflakes .
+        displayName: "pyflakes"
+
+      - script: black . --check --target-version py36 --exclude 'build/|buck-out/|dzzist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|larq/snapshots/'
+        displayName: "Black code style"


### PR DESCRIPTION
This will add two linters to our CI system. `pyflakes` will complain if our code has syntax errors. `black` will check, that our code is properly formatted.