### PR TITLE
Add sticky tab navigation

### DIFF
--- a/docs-theme/partials/header.html
+++ b/docs-theme/partials/header.html
@@ -1,0 +1,47 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+<header class="md-header" data-md-component="header">
+  <nav class="md-header-nav md-grid">
+    <div class="md-flex">
+      <div class="md-flex__cell md-flex__cell--shrink">
+        <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}" title="{{ config.site_name }}" class="md-header-nav__button md-logo">
+          {% if config.theme.logo.icon %}
+            <i class="md-icon">{{ config.theme.logo.icon }}</i>
+          {% else %}
+            <img src="{{ config.theme.logo | url }}" width="24" height="24">
+          {% endif %}
+        </a>
+      </div>
+      <div class="md-flex__cell md-flex__cell--shrink">
+        <label class="md-icon md-icon--menu md-header-nav__button" for="__drawer"></label>
+      </div>
+      <div class="md-flex__cell md-flex__cell--stretch">
+        <div class="md-flex__ellipsis" data-md-component="title">
+            <span class="md-header-nav__topic">
+              <nav class="md-tabs__inner md-grid">
+                <ul class="md-tabs__list">
+                  {% for nav_item in nav %}
+                    {% include "partials/tabs-item.html" %}
+                  {% endfor %}
+                </ul>
+              </nav>
+            </span>
+        </div>
+      </div>
+      <div class="md-flex__cell md-flex__cell--shrink">
+        {% if "search" in config["plugins"] %}
+          <label class="md-icon md-icon--search md-header-nav__button" for="__search"></label>
+          {% include "partials/search.html" %}
+        {% endif %}
+      </div>
+      {% if config.repo_url %}
+        <div class="md-flex__cell md-flex__cell--shrink">
+          <div class="md-header-nav__source">
+            {% include "partials/source.html" %}
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  </nav>
+</header>

--- a/docs-theme/partials/tabs.html
+++ b/docs-theme/partials/tabs.html
@@ -1,0 +1,2 @@
+<!-- Noop component to simplify sidebar appearence -->
+<nav class="md-tabs md-tabs--active"></nav>

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,3 +1,6 @@
 .code-link::before {
   content: "</>";
 }
+.md-header[data-md-state="shadow"] {
+  transition: unset;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,13 +40,12 @@ repo_name: larq/larq
 edit_uri: ""
 theme:
   name: material
+  custom_dir: docs-theme
   logo:
     icon: developer_board
   palette:
     primary: blue
     accent: blue
-  feature:
-    tabs: true
 
 extra:
   social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,8 @@ theme:
   palette:
     primary: blue
     accent: blue
+  feature:
+    tabs: true
 
 extra:
   social:


### PR DESCRIPTION
I used my rusty HTML/CSS skills, to play a bit with our documentation site:
This changes the top level navigation have a persistent tab bar:
<img width="1552" alt="Bildschirmfoto 2019-07-26 um 00 07 24" src="https://user-images.githubusercontent.com/13285808/61914763-891ebb00-af39-11e9-85d7-19c5a4c41ac0.png">

One thing I am not sure about is if it is good to repeat the top-level navigation on the left sidebar or should we switch that back to how it is currently done in https://larq.dev/?