### PR TITLE
Add metrics scope contextmanager

### DIFF
--- a/apidocs.yml
+++ b/apidocs.yml
@@ -14,6 +14,8 @@
     - larq.math+
 - models.md:
     - larq.models+
+- metrics.md:
+    - larq.metrics+
 - quantizers.md:
     - larq.quantizers:
         - larq.quantizers.ste_sign

--- a/larq/__init__.py
+++ b/larq/__init__.py
@@ -3,6 +3,7 @@ import larq.activations as activations
 import larq.callbacks as callbacks
 import larq.constraints as constraints
 import larq.math as math
+import larq.metrics as metrics
 import larq.models as models
 import larq.quantizers as quantizers
 import larq.optimizers as optimizers
@@ -13,6 +14,7 @@ __all__ = [
     "callbacks",
     "constraints",
     "math",
+    "metrics",
     "models",
     "quantizers",
     "optimizers",

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -75,7 +75,8 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     N-D tensor with shape: `(batch_size, ..., input_dim)`. The most common situation
@@ -168,7 +169,8 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     3D tensor with shape: `(batch_size, steps, input_dim)`
@@ -274,7 +276,8 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -387,7 +390,8 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     5D tensor with shape:
@@ -494,7 +498,8 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
         the output of the layer (its 'activation').
     depthwise_constraint: Constraint function applied to the depthwise kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -606,7 +611,8 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         pointwise kernel after being updated by an `Optimizer`.
     bias_constraint: Optional projection function to be applied to the
         bias after being updated by an `Optimizer`.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.metrics.scope` are used. Available metrics: `flip_ration`.
     trainable: Boolean, if `True` the weights of this layer will be marked as
         trainable (and listed in `layer.trainable_weights`).
     name: A string, the name of the layer.
@@ -726,7 +732,8 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
     depthwise_constraint: Constraint function applied to the depthwise kernel matrix.
     pointwise_constraint: Constraint function applied to the pointwise kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -854,7 +861,8 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -979,7 +987,8 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
 
     # Input shape
     5D tensor with shape:
@@ -1096,7 +1105,8 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
     implementation: implementation mode, either `1` or `2`.
         `1` loops over input spatial locations to perform the forward pass.
         It is memory-efficient but performs a lot of (small) ops.
@@ -1230,7 +1240,8 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
-    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
+    metrics: An array of metrics to add to the layer. If `None` the metrics set in
+        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
     implementation: implementation mode, either `1` or `2`.
         `1` loops over input spatial locations to perform the forward pass.
         It is memory-efficient but performs a lot of (small) ops.

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -7,7 +7,7 @@ is equivalent to a full precision layer.
 """
 
 import tensorflow as tf
-from larq import utils
+from larq import utils, metrics
 from larq.layers_base import (
     QuantizerBase,
     QuantizerDepthwiseBase,
@@ -99,6 +99,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -114,6 +115,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -193,6 +195,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -213,6 +216,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -302,6 +306,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -322,6 +327,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -417,6 +423,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -437,6 +444,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -515,6 +523,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
         activity_regularizer=None,
         depthwise_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -534,6 +543,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
             activity_regularizer=activity_regularizer,
             depthwise_constraint=depthwise_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -620,6 +630,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         depthwise_constraint=None,
         pointwise_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -645,6 +656,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
             depthwise_constraint=depthwise_constraint,
             pointwise_constraint=pointwise_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -747,6 +759,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         depthwise_constraint=None,
         pointwise_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -772,6 +785,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
             depthwise_constraint=depthwise_constraint,
             pointwise_constraint=pointwise_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -874,6 +888,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -894,6 +909,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -995,6 +1011,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         super().__init__(
@@ -1014,6 +1031,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             **kwargs,
         )
 
@@ -1119,6 +1137,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         implementation=1,
         **kwargs,
     ):
@@ -1139,6 +1158,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
             activity_regularizer=activity_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
+            metrics=metrics,
             implementation=implementation,
             **kwargs,
         )
@@ -1256,6 +1276,7 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        metrics=metrics.get_training_metrics(),
         implementation=1,
         **kwargs,
     ):
@@ -1277,5 +1298,6 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             implementation=implementation,
+            metrics=metrics,
             **kwargs,
         )

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -75,6 +75,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     N-D tensor with shape: `(batch_size, ..., input_dim)`. The most common situation
@@ -167,6 +168,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     3D tensor with shape: `(batch_size, steps, input_dim)`
@@ -272,6 +274,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -384,6 +387,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     5D tensor with shape:
@@ -490,6 +494,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
         the output of the layer (its 'activation').
     depthwise_constraint: Constraint function applied to the depthwise kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -601,6 +606,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         pointwise kernel after being updated by an `Optimizer`.
     bias_constraint: Optional projection function to be applied to the
         bias after being updated by an `Optimizer`.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
     trainable: Boolean, if `True` the weights of this layer will be marked as
         trainable (and listed in `layer.trainable_weights`).
     name: A string, the name of the layer.
@@ -720,6 +726,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
     depthwise_constraint: Constraint function applied to the depthwise kernel matrix.
     pointwise_constraint: Constraint function applied to the pointwise kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -847,6 +854,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     4D tensor with shape:
@@ -971,6 +979,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
 
     # Input shape
     5D tensor with shape:
@@ -1087,6 +1096,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
     implementation: implementation mode, either `1` or `2`.
         `1` loops over input spatial locations to perform the forward pass.
         It is memory-efficient but performs a lot of (small) ops.
@@ -1220,6 +1230,7 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
         the output of the layer (its "activation").
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
+    metrics: An array of metrics to add to the layer. Available metrics: `flip_ration`.
     implementation: implementation mode, either `1` or `2`.
         `1` loops over input spatial locations to perform the forward pass.
         It is memory-efficient but performs a lot of (small) ops.

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -7,7 +7,7 @@ is equivalent to a full precision layer.
 """
 
 import tensorflow as tf
-from larq import utils, metrics
+from larq import utils
 from larq.layers_base import (
     QuantizerBase,
     QuantizerDepthwiseBase,
@@ -100,7 +100,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -197,7 +197,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -309,7 +309,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -427,7 +427,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -528,7 +528,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
         activity_regularizer=None,
         depthwise_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -636,7 +636,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         depthwise_constraint=None,
         pointwise_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -766,7 +766,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         depthwise_constraint=None,
         pointwise_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -896,7 +896,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -1020,7 +1020,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         **kwargs,
     ):
         super().__init__(
@@ -1147,7 +1147,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         implementation=1,
         **kwargs,
     ):
@@ -1287,7 +1287,7 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
-        metrics=metrics.get_training_metrics(),
+        metrics=None,
         implementation=1,
         **kwargs,
     ):

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -76,7 +76,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
     kernel_constraint: Constraint function applied to the `kernel` weights matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     N-D tensor with shape: `(batch_size, ..., input_dim)`. The most common situation
@@ -170,7 +170,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     3D tensor with shape: `(batch_size, steps, input_dim)`
@@ -277,7 +277,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     4D tensor with shape:
@@ -391,7 +391,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     5D tensor with shape:
@@ -499,7 +499,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
     depthwise_constraint: Constraint function applied to the depthwise kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     4D tensor with shape:
@@ -612,7 +612,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
     bias_constraint: Optional projection function to be applied to the
         bias after being updated by an `Optimizer`.
         metrics: An array of metrics to add to the layer. If `None` the metrics set in
-            `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+            `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
     trainable: Boolean, if `True` the weights of this layer will be marked as
         trainable (and listed in `layer.trainable_weights`).
     name: A string, the name of the layer.
@@ -733,7 +733,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
     pointwise_constraint: Constraint function applied to the pointwise kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     4D tensor with shape:
@@ -862,7 +862,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     4D tensor with shape:
@@ -988,7 +988,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
 
     # Input shape
     5D tensor with shape:
@@ -1106,7 +1106,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
     implementation: implementation mode, either `1` or `2`.
         `1` loops over input spatial locations to perform the forward pass.
         It is memory-efficient but performs a lot of (small) ops.
@@ -1241,7 +1241,7 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
     kernel_constraint: Constraint function applied to the kernel matrix.
     bias_constraint: Constraint function applied to the bias vector.
     metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.metrics.scope` are used. Available metrics: `flip_ration`.
+        `larq.metrics.scope` are used. Available metrics: `flip_ratio`.
     implementation: implementation mode, either `1` or `2`.
         `1` loops over input spatial locations to perform the forward pass.
         It is memory-efficient but performs a lot of (small) ops.

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -17,9 +17,6 @@ class QuantizerBase(tf.keras.layers.Layer):
     """
 
     def __init__(self, *args, input_quantizer=None, kernel_quantizer=None, **kwargs):
-        # This is currently undocumented until we have explored better options
-        self._custom_metrics = kwargs.pop("metrics", ["flip_ratio"])
-
         self.input_quantizer = quantizers.get(input_quantizer)
         self.kernel_quantizer = quantizers.get(kernel_quantizer)
         self.quantized_latent_weights = []
@@ -37,7 +34,10 @@ class QuantizerBase(tf.keras.layers.Layer):
         if self.kernel_quantizer:
             self.quantized_latent_weights.append(self.kernel)
             self.quantizers.append(self.kernel_quantizer)
-            if "flip_ratio" in self._custom_metrics and utils.supports_metrics():
+            if (
+                "flip_ratio" in metrics.get_training_metrics()
+                and utils.supports_metrics()
+            ):
                 self.flip_ratio = metrics.FlipRatio(
                     values_shape=self.kernel.shape, name=f"flip_ratio/{self.name}"
                 )
@@ -76,9 +76,6 @@ class QuantizerDepthwiseBase(tf.keras.layers.Layer):
     """
 
     def __init__(self, *args, input_quantizer=None, depthwise_quantizer=None, **kwargs):
-        # This is currently undocumented until we have explored better options
-        self._custom_metrics = kwargs.pop("metrics", ["flip_ratio"])
-
         self.input_quantizer = quantizers.get(input_quantizer)
         self.depthwise_quantizer = quantizers.get(depthwise_quantizer)
         self.quantized_latent_weights = []
@@ -96,7 +93,10 @@ class QuantizerDepthwiseBase(tf.keras.layers.Layer):
         if self.depthwise_quantizer:
             self.quantized_latent_weights.append(self.depthwise_kernel)
             self.quantizers.append(self.depthwise_quantizer)
-            if "flip_ratio" in self._custom_metrics and utils.supports_metrics():
+            if (
+                "flip_ratio" in metrics.get_training_metrics()
+                and utils.supports_metrics()
+            ):
                 self.flip_ratio = metrics.FlipRatio(
                     values_shape=self.depthwise_kernel.shape,
                     name=f"flip_ratio/{self.name}",
@@ -147,9 +147,6 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         pointwise_quantizer=None,
         **kwargs,
     ):
-        # This is currently undocumented until we have explored better options
-        self._custom_metrics = kwargs.pop("metrics", ["flip_ratio"])
-
         self.input_quantizer = quantizers.get(input_quantizer)
         self.depthwise_quantizer = quantizers.get(depthwise_quantizer)
         self.pointwise_quantizer = quantizers.get(pointwise_quantizer)
@@ -173,7 +170,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if self.depthwise_quantizer:
             self.quantized_latent_weights.append(self.depthwise_kernel)
             self.quantizers.append(self.depthwise_quantizer)
-            if "flip_ratio" in self._custom_metrics:
+            if "flip_ratio" in metrics.get_training_metrics():
                 self.depthwise_flip_ratio = metrics.FlipRatio(
                     values_shape=self.depthwise_kernel.shape,
                     name=f"flip_ratio/{self.name}_depthwise",
@@ -181,7 +178,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if self.pointwise_quantizer:
             self.quantized_latent_weights.append(self.pointwise_kernel)
             self.quantizers.append(self.pointwise_quantizer)
-            if "flip_ratio" in self._custom_metrics:
+            if "flip_ratio" in metrics.get_training_metrics():
                 self.pointwise_flip_ratio = metrics.FlipRatio(
                     values_shape=self.pointwise_kernel.shape,
                     name=f"flip_ratio/{self.name}_pointwise",

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -16,11 +16,19 @@ class QuantizerBase(tf.keras.layers.Layer):
     equivalent to `Layer`.
     """
 
-    def __init__(self, *args, input_quantizer=None, kernel_quantizer=None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        input_quantizer=None,
+        kernel_quantizer=None,
+        metrics=metrics.get_training_metrics(),
+        **kwargs,
+    ):
         self.input_quantizer = quantizers.get(input_quantizer)
         self.kernel_quantizer = quantizers.get(kernel_quantizer)
         self.quantized_latent_weights = []
         self.quantizers = []
+        self._custom_metrics = metrics
 
         super().__init__(*args, **kwargs)
         if kernel_quantizer and not self.kernel_constraint:
@@ -34,10 +42,7 @@ class QuantizerBase(tf.keras.layers.Layer):
         if self.kernel_quantizer:
             self.quantized_latent_weights.append(self.kernel)
             self.quantizers.append(self.kernel_quantizer)
-            if (
-                "flip_ratio" in metrics.get_training_metrics()
-                and utils.supports_metrics()
-            ):
+            if "flip_ratio" in self._custom_metrics and utils.supports_metrics():
                 self.flip_ratio = metrics.FlipRatio(
                     values_shape=self.kernel.shape, name=f"flip_ratio/{self.name}"
                 )
@@ -75,11 +80,19 @@ class QuantizerDepthwiseBase(tf.keras.layers.Layer):
     equivalent to `Layer`.
     """
 
-    def __init__(self, *args, input_quantizer=None, depthwise_quantizer=None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        input_quantizer=None,
+        depthwise_quantizer=None,
+        metrics=metrics.get_training_metrics(),
+        **kwargs,
+    ):
         self.input_quantizer = quantizers.get(input_quantizer)
         self.depthwise_quantizer = quantizers.get(depthwise_quantizer)
         self.quantized_latent_weights = []
         self.quantizers = []
+        self._custom_metrics = metrics
 
         super().__init__(*args, **kwargs)
         if depthwise_quantizer and not self.depthwise_constraint:
@@ -93,10 +106,7 @@ class QuantizerDepthwiseBase(tf.keras.layers.Layer):
         if self.depthwise_quantizer:
             self.quantized_latent_weights.append(self.depthwise_kernel)
             self.quantizers.append(self.depthwise_quantizer)
-            if (
-                "flip_ratio" in metrics.get_training_metrics()
-                and utils.supports_metrics()
-            ):
+            if "flip_ratio" in self._custom_metrics and utils.supports_metrics():
                 self.flip_ratio = metrics.FlipRatio(
                     values_shape=self.depthwise_kernel.shape,
                     name=f"flip_ratio/{self.name}",
@@ -145,6 +155,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         input_quantizer=None,
         depthwise_quantizer=None,
         pointwise_quantizer=None,
+        metrics=metrics.get_training_metrics(),
         **kwargs,
     ):
         self.input_quantizer = quantizers.get(input_quantizer)
@@ -152,6 +163,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         self.pointwise_quantizer = quantizers.get(pointwise_quantizer)
         self.quantized_latent_weights = []
         self.quantizers = []
+        self._custom_metrics = metrics
 
         super().__init__(*args, **kwargs)
         if depthwise_quantizer and not self.depthwise_constraint:
@@ -170,7 +182,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if self.depthwise_quantizer:
             self.quantized_latent_weights.append(self.depthwise_kernel)
             self.quantizers.append(self.depthwise_quantizer)
-            if "flip_ratio" in metrics.get_training_metrics():
+            if "flip_ratio" in self._custom_metrics and utils.supports_metrics():
                 self.depthwise_flip_ratio = metrics.FlipRatio(
                     values_shape=self.depthwise_kernel.shape,
                     name=f"flip_ratio/{self.name}_depthwise",
@@ -178,7 +190,7 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if self.pointwise_quantizer:
             self.quantized_latent_weights.append(self.pointwise_kernel)
             self.quantizers.append(self.pointwise_quantizer)
-            if "flip_ratio" in metrics.get_training_metrics():
+            if "flip_ratio" in self._custom_metrics and utils.supports_metrics():
                 self.pointwise_flip_ratio = metrics.FlipRatio(
                     values_shape=self.pointwise_kernel.shape,
                     name=f"flip_ratio/{self.name}_pointwise",

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -77,16 +77,17 @@ class LayersTest(keras_parameterized.TestCase):
         input_data = random_input(input_shape)
         random_weight = np.random.random() - 0.5
 
-        quant_output = testing_utils.layer_test(
-            quantized_layer,
-            kwargs=dict(
-                **kwargs,
-                kernel_quantizer="ste_sign",
-                input_quantizer="ste_sign",
-                kernel_initializer=tf.keras.initializers.constant(random_weight),
-            ),
-            input_data=input_data,
-        )
+        with lq.metrics.scope(["flip_ratio"]):
+            quant_output = testing_utils.layer_test(
+                quantized_layer,
+                kwargs=dict(
+                    **kwargs,
+                    kernel_quantizer="ste_sign",
+                    input_quantizer="ste_sign",
+                    kernel_initializer=tf.keras.initializers.constant(random_weight),
+                ),
+                input_data=input_data,
+            )
 
         fp_output = testing_utils.layer_test(
             layer,
@@ -105,16 +106,17 @@ class LayersTest(keras_parameterized.TestCase):
         input_data = random_input((2, 3, 7, 6))
         random_weight = np.random.random() - 0.5
 
-        quant_output = testing_utils.layer_test(
-            lq.layers.QuantDepthwiseConv2D,
-            kwargs=dict(
-                kernel_size=3,
-                depthwise_quantizer="ste_sign",
-                input_quantizer="ste_sign",
-                depthwise_initializer=tf.keras.initializers.constant(random_weight),
-            ),
-            input_data=input_data,
-        )
+        with lq.metrics.scope(["flip_ratio"]):
+            quant_output = testing_utils.layer_test(
+                lq.layers.QuantDepthwiseConv2D,
+                kwargs=dict(
+                    kernel_size=3,
+                    depthwise_quantizer="ste_sign",
+                    input_quantizer="ste_sign",
+                    depthwise_initializer=tf.keras.initializers.constant(random_weight),
+                ),
+                input_data=input_data,
+            )
 
         fp_output = testing_utils.layer_test(
             tf.keras.layers.DepthwiseConv2D,
@@ -148,19 +150,24 @@ class LayersTest(keras_parameterized.TestCase):
         random_d_kernel = np.random.random() - 0.5
         random_p_kernel = np.random.random() - 0.5
 
-        quant_output = testing_utils.layer_test(
-            quantized_layer,
-            kwargs=dict(
-                filters=3,
-                kernel_size=3,
-                depthwise_quantizer="ste_sign",
-                pointwise_quantizer="ste_sign",
-                input_quantizer="ste_sign",
-                depthwise_initializer=tf.keras.initializers.constant(random_d_kernel),
-                pointwise_initializer=tf.keras.initializers.constant(random_p_kernel),
-            ),
-            input_data=input_data,
-        )
+        with lq.metrics.scope(["flip_ratio"]):
+            quant_output = testing_utils.layer_test(
+                quantized_layer,
+                kwargs=dict(
+                    filters=3,
+                    kernel_size=3,
+                    depthwise_quantizer="ste_sign",
+                    pointwise_quantizer="ste_sign",
+                    input_quantizer="ste_sign",
+                    depthwise_initializer=tf.keras.initializers.constant(
+                        random_d_kernel
+                    ),
+                    pointwise_initializer=tf.keras.initializers.constant(
+                        random_p_kernel
+                    ),
+                ),
+                input_data=input_data,
+            )
 
         fp_output = testing_utils.layer_test(
             layer,
@@ -225,6 +232,21 @@ def test_separable_layer_does_not_warn(caplog):
         pointwise_constraint="weight_clip",
     )
     assert caplog.records == []
+
+
+def test_metrics():
+    model = tf.keras.models.Sequential(
+        [lq.layers.QuantDense(3, kernel_quantizer="ste_sign", input_shape=(32,))]
+    )
+    model.compile(loss="mse", optimizer="sgd")
+    assert len(model.layers[0].metrics) == 0
+
+    with lq.metrics.scope(["flip_ratio"]):
+        model = tf.keras.models.Sequential(
+            [lq.layers.QuantDense(3, kernel_quantizer="ste_sign", input_shape=(32,))]
+        )
+        model.compile(loss="mse", optimizer="sgd")
+    assert len(model.layers[0].metrics) == 1
 
 
 @pytest.mark.parametrize(

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -245,7 +245,7 @@ def test_metrics():
         model = tf.keras.models.Sequential(
             [lq.layers.QuantDense(3, kernel_quantizer="ste_sign", input_shape=(32,))]
         )
-        model.compile(loss="mse", optimizer="sgd")
+    model.compile(loss="mse", optimizer="sgd")
     assert len(model.layers[0]._metrics) == 1
 
 

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -275,6 +275,7 @@ def test_layer_kwargs(quant_layer, layer):
         "kernel_quantizer",
         "depthwise_quantizer",
         "pointwise_quantizer",
+        "metrics",
     ):
         try:
             quant_params_list.remove(p)

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -239,14 +239,14 @@ def test_metrics():
         [lq.layers.QuantDense(3, kernel_quantizer="ste_sign", input_shape=(32,))]
     )
     model.compile(loss="mse", optimizer="sgd")
-    assert len(model.layers[0].metrics) == 0
+    assert len(model.layers[0]._metrics) == 0
 
     with lq.metrics.scope(["flip_ratio"]):
         model = tf.keras.models.Sequential(
             [lq.layers.QuantDense(3, kernel_quantizer="ste_sign", input_shape=(32,))]
         )
         model.compile(loss="mse", optimizer="sgd")
-    assert len(model.layers[0].metrics) == 1
+    assert len(model.layers[0]._metrics) == 1
 
 
 @pytest.mark.parametrize(

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -248,6 +248,19 @@ def test_metrics():
     model.compile(loss="mse", optimizer="sgd")
     assert len(model.layers[0]._metrics) == 1
 
+    model = tf.keras.models.Sequential(
+        [
+            lq.layers.QuantDense(
+                3,
+                kernel_quantizer="ste_sign",
+                metrics=["flip_ratio"],
+                input_shape=(32,),
+            )
+        ]
+    )
+    model.compile(loss="mse", optimizer="sgd")
+    assert len(model.layers[0]._metrics) == 1
+
 
 @pytest.mark.parametrize(
     "quant_layer,layer",

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -30,7 +30,7 @@ def scope(metrics=[]):
 
     # Arguments
     metrics: Iterable of metrics to add to layers defined inside this context.
-        Currently only the `flip_ration` metric is available.
+        Currently only the `flip_ratio` metric is available.
     """
     for metric in metrics:
         if metric not in _AVAILABLE_METRICS:

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -48,7 +48,7 @@ def get_training_metrics():
     """Retrieves a live reference to the training metrics in the current scope.
 
     Updating and clearing training metrics using `larq.metrics.scope` is preferred,
-    but `get_custom_objects` can be used to directly access them.
+    but `get_training_metrics` can be used to directly access them.
 
     !!! example
         ```python

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -12,10 +12,16 @@ except:  # TensorFlow 1.13 doesn't export this as a public API
 __all__ = ["scope", "get_training_metrics"]
 
 _GLOBAL_TRAINING_METRICS = set()
+_AVAILABLE_METRICS = {"flip_ratio"}
 
 
 @contextmanager
 def scope(metrics=[]):
+    for metric in metrics:
+        if metric not in _AVAILABLE_METRICS:
+            raise ValueError(
+                f"Unknown training metric '{metric}'. Available metrics: {_AVAILABLE_METRICS}."
+            )
     backup = _GLOBAL_TRAINING_METRICS.copy()
     _GLOBAL_TRAINING_METRICS.update(metrics)
     yield _GLOBAL_TRAINING_METRICS

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -17,6 +17,21 @@ _AVAILABLE_METRICS = {"flip_ratio"}
 
 @contextmanager
 def scope(metrics=[]):
+    """A context manager to set the training metrics to be used in layers.
+
+    !!! example
+        ```python
+        with larq.metrics.scope(["flip_ratio"]):
+            model = tf.keras.models.Sequential(
+                [larq.layers.QuantDense(3, kernel_quantizer="ste_sign", input_shape=(32,))]
+            )
+        model.compile(loss="mse", optimizer="sgd")
+        ```
+
+    # Arguments
+    metrics: Iterable of metrics to add to layers defined inside this context.
+        Currently only the `flip_ration` metric is available.
+    """
     for metric in metrics:
         if metric not in _AVAILABLE_METRICS:
             raise ValueError(
@@ -30,6 +45,20 @@ def scope(metrics=[]):
 
 
 def get_training_metrics():
+    """Retrieves a live reference to the training metrics in the current scope.
+
+    Updating and clearing training metrics using `larq.metrics.scope` is preferred,
+    but `get_custom_objects` can be used to directly access them.
+
+    !!! example
+        ```python
+        get_training_metrics().clear()
+        get_training_metrics().add("flip_ratio")
+        ```
+
+    # Returns
+    A set of training metrics in the current scope.
+    """
     return _GLOBAL_TRAINING_METRICS
 
 

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,11 +1,30 @@
 import tensorflow as tf
 from larq import utils
 import numpy as np
+from contextlib import contextmanager
 
 try:
     from tensorflow.keras.metrics import Metric
 except:  # TensorFlow 1.13 doesn't export this as a public API
     from tensorflow.python.keras.metrics import Metric
+
+
+__all__ = ["scope", "get_training_metrics"]
+
+_GLOBAL_TRAINING_METRICS = set()
+
+
+@contextmanager
+def scope(metrics=[]):
+    backup = _GLOBAL_TRAINING_METRICS.copy()
+    _GLOBAL_TRAINING_METRICS.update(metrics)
+    yield _GLOBAL_TRAINING_METRICS
+    _GLOBAL_TRAINING_METRICS.clear()
+    _GLOBAL_TRAINING_METRICS.update(backup)
+
+
+def get_training_metrics():
+    return _GLOBAL_TRAINING_METRICS
 
 
 class FlipRatio(Metric):

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -4,6 +4,13 @@ from tensorflow.python.keras import keras_parameterized
 import pytest
 
 
+def test_scope():
+    assert metrics.get_training_metrics() == set()
+    with metrics.scope(["flip_ratio", "new_metric"]):
+        assert metrics.get_training_metrics() == {"flip_ratio", "new_metric"}
+    assert metrics.get_training_metrics() == set()
+
+
 class FlipRatioTest(keras_parameterized.TestCase):
     def test_config(self):
         mcv = metrics.FlipRatio(

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -6,9 +6,12 @@ import pytest
 
 def test_scope():
     assert metrics.get_training_metrics() == set()
-    with metrics.scope(["flip_ratio", "new_metric"]):
-        assert metrics.get_training_metrics() == {"flip_ratio", "new_metric"}
+    with metrics.scope(["flip_ratio"]):
+        assert metrics.get_training_metrics() == {"flip_ratio"}
     assert metrics.get_training_metrics() == set()
+    with pytest.raises(ValueError, match=r".*unknown_metric.*"):
+        with metrics.scope(["flip_ratio", "unknown_metric"]):
+            pass
 
 
 class FlipRatioTest(keras_parameterized.TestCase):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
       - Optimizers: api/optimizers.md
       - Math: api/math.md
       - Models: api/models.md
+      - Metrics: api/metrics.md
   - Models:
       - Larq Zoo: models/index.md
       - Examples: models/examples.md


### PR DESCRIPTION
This allows us to configure training metrics using a context manager similar to `tf.keras.utils.custom_object_scope` or `tf.name_scope`.

I disabled the metrics by default since they can slightly increase runtime and memory consumption.

The API I propose is the following:
```python
with lq.metrics.scope(["flip_ratio"]):
    model = tf.keras.models.Sequential([lq.layers.QuantDense(3, kernel_quantizer="ste_sign", input_shape=(32,))])
model.compile(loss="mse", optimizer="sgd")
```

I still need to add documentation, but I though it would be good to get some feedback first.