### PR TITLE
Revert "Automatically Publish docs from CI"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,11 @@ Inside the project directory run:
 ./larqdocs.sh serve
 ```
 
-A new version of the documentation will be automatically published once merged into the master branch.
+To publish a new version to github pages run:
+
+```shell
+./larqdocs.sh gh-deploy --force
+```
 
 ## Code style
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,9 +41,6 @@ jobs:
       vmImage: "Ubuntu-16.04"
 
     steps:
-      - checkout: self
-        persistCredentials: true
-
       - task: UsePythonVersion@0
         inputs:
           versionSpec: "3.7"
@@ -57,13 +54,6 @@ jobs:
 
       - script: ./larqdocs.sh build
         displayName: "Build docs"
-
-      - script: |
-          git config --local user.name "Azure Pipelines"
-          git config --local user.email "azuredevops@microsoft.com"
-          ./larqdocs.sh gh-deploy --force --remote-name https://$(github_pat)@github.com/larq/larq.git
-        displayName: "Publish GitHub Pages"
-        condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
   - job: "Lint"
     pool:


### PR DESCRIPTION
This reverts commit cc68d063e5e35748bf47121c7175dfe59556efa4.

While Azure CI has the correct scopes to push to larq, it doesn't correctly trigger a GitHub pages build. We need to revisit this some day. Let's remove it for now, since it's partially broken anyway.