### PR TITLE
Cleanup ternary quantizer and add alias to ste_tern

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -247,6 +247,7 @@ class SteTern:
             "ternary_weight_networks": self.ternary_weight_networks,
         }
 
+
 ste_tern = SteTern
 
 

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -167,8 +167,8 @@ def approx_sign(x):
 @utils.set_precision(2)
 @dataclass
 class SteTern:
-    r"""
-    Ternarization function.
+    r"""Instantiates a ternarization quantizer.
+
     \\[
     q(x) = \begin{cases}
     +1 & x > \Delta \\\
@@ -198,12 +198,14 @@ class SteTern:
     ```
 
     # Arguments
-    x: Input tensor.
     threshold_value: The value for the threshold, $\Delta$.
     ternary_weight_networks: Boolean of whether to use the Ternary Weight Networks threshold calculation.
 
     # Returns
-    Ternarized tensor.
+    Ternarization function
+
+    # Aliases
+    - `larq.quantizers.ste_tern`
 
     # References
     - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
@@ -213,6 +215,14 @@ class SteTern:
     ternary_weight_networks: bool = False
 
     def __call__(self, x):
+        """Calls ternarization function.
+
+        # Arguments
+        x: Input tensor.
+
+        # Returns
+        Ternarized tensor.
+        """
         x = tf.clip_by_value(x, -1, 1)
         if self.ternary_weight_networks:
             threshold = self.threshold_twn(x)
@@ -236,6 +246,8 @@ class SteTern:
             "threshold_value": self.threshold_value,
             "ternary_weight_networks": self.ternary_weight_networks,
         }
+
+ste_tern = SteTern
 
 
 def serialize(initializer):

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -35,6 +35,7 @@ average pooling - and shortcut connections may result in non-binary input
 to the convolutions.
 """
 
+from dataclasses import dataclass
 import tensorflow as tf
 from larq import utils, math
 
@@ -164,6 +165,7 @@ def approx_sign(x):
 
 @utils.register_keras_custom_object
 @utils.set_precision(2)
+@dataclass
 class SteTern:
     r"""
     Ternarization function.
@@ -181,7 +183,7 @@ class SteTern:
     \\[
     \Delta = \frac{0.7}{n} \sum_{i=1}^{n} |W_i|
     \\]
-    where we assume that $W_i$ is generated from a normal distribution. 
+    where we assume that $W_i$ is generated from a normal distribution.
 
     The gradient is estimated using the Straight-Through Estimator
     (essentially the Ternarization is replaced by a clipped identity on the
@@ -207,9 +209,8 @@ class SteTern:
     - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
     """
 
-    def __init__(self, threshold_value=0.05, ternary_weight_networks=False):
-        self.threshold_value = threshold_value
-        self.ternary_weight_networks = ternary_weight_networks
+    threshold_value: float = 0.05
+    ternary_weight_networks: bool = False
 
     def __call__(self, x):
         x = tf.clip_by_value(x, -1, 1)

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -5,31 +5,20 @@ import pytest
 import larq as lq
 
 
+@pytest.mark.parametrize("module", [lq.quantizers, tf.keras.activations])
 @pytest.mark.parametrize("name", ["ste_sign", "approx_sign", "magnitude_aware_sign"])
-def test_serialization(name):
-    fn = lq.quantizers.get(name)
+def test_serialization(module, name):
+    fn = module.get(name)
     ref_fn = getattr(lq.quantizers, name)
     assert fn == ref_fn
     assert type(fn.precision) == int
-    config = lq.quantizers.serialize(fn)
-    fn = lq.quantizers.deserialize(config)
+    config = module.serialize(fn)
+    fn = module.deserialize(config)
     assert fn == ref_fn
     assert type(fn.precision) == int
-    fn = lq.quantizers.get(ref_fn)
+    fn = module.get(ref_fn)
     assert fn == ref_fn
     assert type(fn.precision) == int
-
-
-@pytest.mark.parametrize("name", ["ste_sign", "approx_sign", "magnitude_aware_sign"])
-def test_serialization_as_activation(name):
-    fn = tf.keras.activations.get(name)
-    ref_fn = getattr(lq.quantizers, name)
-    assert fn == ref_fn
-    config = tf.keras.activations.serialize(fn)
-    fn = tf.keras.activations.deserialize(config)
-    assert fn == ref_fn
-    fn = tf.keras.activations.get(ref_fn)
-    assert fn == ref_fn
 
 
 def test_invalid_usage():


### PR DESCRIPTION
This fixes the documentation and adds an alias to `ste_tern` to make it consistent with other quantizers.