### PR TITLE
Properly register aliases and convert weight_clip to dataclass

### DIFF
--- a/apidocs.yml
+++ b/apidocs.yml
@@ -5,7 +5,8 @@
 - callbacks.md:
     - larq.callbacks+
 - constraints.md:
-    - larq.constraints+
+    - larq.constraints:
+      - larq.constraints.WeightClip
 - optimizers.md:
     - larq.optimizers:
         - larq.optimizers_v2.Bop

--- a/larq/constraints.py
+++ b/larq/constraints.py
@@ -44,6 +44,4 @@ class WeightClip(tf.keras.constraints.Constraint):
 
 
 # Aliases
-@utils.register_keras_custom_object
-class weight_clip(WeightClip):
-    pass
+weight_clip = utils.register_alias(WeightClip, "weight_clip")

--- a/larq/constraints.py
+++ b/larq/constraints.py
@@ -20,9 +20,11 @@ lq.layers.QuantDense(64, kernel_constraint=lq.constraints.WeightClip(2.))
 
 import tensorflow as tf
 from larq import utils
+from dataclasses import dataclass
 
 
 @utils.register_keras_custom_object
+@dataclass
 class WeightClip(tf.keras.constraints.Constraint):
     """Weight Clip constraint
 
@@ -31,10 +33,12 @@ class WeightClip(tf.keras.constraints.Constraint):
 
     # Arguments
     clip_value: The value to clip incoming weights.
+
+    # Aliases
+    - `larq.constraints.weight_clip`
     """
 
-    def __init__(self, clip_value=1):
-        self.clip_value = clip_value
+    clip_value: float = 1.0
 
     def __call__(self, x):
         return tf.clip_by_value(x, -self.clip_value, self.clip_value)

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -248,7 +248,7 @@ class SteTern:
         }
 
 
-ste_tern = SteTern
+ste_tern = utils.register_alias(SteTern, "ste_tern")
 
 
 def serialize(initializer):

--- a/larq/utils.py
+++ b/larq/utils.py
@@ -10,6 +10,11 @@ def register_keras_custom_object(cls):
     return cls
 
 
+def register_alias(cls, name):
+    get_custom_objects()[name] = cls
+    return cls
+
+
 def tf_1_14_or_newer():
     return LooseVersion(tf.__version__) >= LooseVersion("1.14.0")
 


### PR DESCRIPTION
This adds a new `utils.register_alias` function that can be used to correctly register aliases. It furthermore simplifies the current `WeightClip` constrain by converting it to a `dataclass`.