### PR TITLE
Cleanup quantizer classes

### DIFF
--- a/apidocs.yml
+++ b/apidocs.yml
@@ -18,8 +18,4 @@
 - metrics.md:
     - larq.metrics+
 - quantizers.md:
-    - larq.quantizers:
-        - larq.quantizers.ste_sign
-        - larq.quantizers.approx_sign
-        - larq.quantizers.magnitude_aware_sign
-        - larq.quantizers.SteTern
+    - larq.quantizers+

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -38,6 +38,12 @@ to the convolutions.
 import tensorflow as tf
 from larq import utils, math
 
+try:
+    from tensorflow import is_tensor
+except:
+    # For compatibility with TensorFlow 1.13
+    from tensorflow.python.framework.tensor_util import is_tensor
+
 __all__ = ["ste_sign", "approx_sign", "magnitude_aware_sign", "SteTern", "ste_tern"]
 
 
@@ -81,7 +87,7 @@ class QuantizerFunctionWrapper:
     def get_config(self):
         return {
             k: tf.keras.backend.eval(v)
-            if tf.is_tensor(v) or isinstance(v, tf.Variable)
+            if is_tensor(v) or isinstance(v, tf.Variable)
             else v
             for k, v in self._fn_kwargs.items()
         }

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -37,7 +37,6 @@ to the convolutions.
 
 import tensorflow as tf
 from larq import utils, math
-from tensorflow.python.keras.utils import tf_utils
 
 __all__ = ["ste_sign", "approx_sign", "magnitude_aware_sign", "SteTern", "ste_tern"]
 
@@ -81,7 +80,9 @@ class QuantizerFunctionWrapper:
 
     def get_config(self):
         return {
-            k: tf.keras.backend.eval(v) if tf_utils.is_tensor_or_variable(v) else v
+            k: tf.keras.backend.eval(v)
+            if tf.is_tensor(v) or isinstance(v, tf.Variable)
+            else v
             for k, v in self._fn_kwargs.items()
         }
 

--- a/plot_activation.py
+++ b/plot_activation.py
@@ -1,5 +1,4 @@
 from functools import reduce
-import inspect
 import matplotlib as mpl
 import numpy as np
 import larq as lq
@@ -52,8 +51,6 @@ def plot(function):
 
 def html_format(source, language, css_class, options, md):
     function = reduce(getattr, [lq, *source.split(".")])
-    if inspect.isclass(function):
-        function = function()
     fig = plot(function)
     tmp = StringIO()
     fig.savefig(tmp, format="svg", bbox_inches="tight", pad_inches=0)


### PR DESCRIPTION
This adds `QuantizerFunctionWrapper` that can be used to wrap a simple quantizer function into a serializable class that will retain the config after reloading from a `.h5` model file.

This allows quantizers to be used either as either
```python
input_quantizer=lq.quantizers.ste_tern
```
or
```python
input_quantizer=lq.quantizers.SteTern(threshold_value=0.05)
```

As mentioned in https://github.com/larq/larq/pull/178#discussion_r312930868 the current `ste_tern` alias is a bit inconsistent this PR cleans this up and introduces a proper way to add configurable quantizers.