### PR TITLE
Allow to configure gradient clipping in quantizers

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -409,6 +409,8 @@ def deserialize(name, custom_objects=None):
 def get(identifier):
     if identifier is None:
         return None
+    if isinstance(identifier, dict):
+        return deserialize(identifier)
     if isinstance(identifier, str):
         return deserialize(str(identifier))
     if callable(identifier):

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -130,8 +130,8 @@ def ste_sign(x, clip_value=1.0):
     (essentially the binarization is replaced by a clipped identity on the
     backward pass).
     \\[\frac{\partial q(x)}{\partial x} = \begin{cases}
-      1 & \left|x\right| \leq t_\text{clip} \\\
-      0 & \left|x\right| > t_\text{clip}
+      1 & \left|x\right| \leq \texttt{clip_value} \\\
+      0 & \left|x\right| > \texttt{clip_value}
     \end{cases}\\]
 
     ```plot-activation
@@ -140,7 +140,7 @@ def ste_sign(x, clip_value=1.0):
 
     # Arguments
     x: Input tensor.
-    clip_value: Threshold for clipping gradients ($t_\text{clip}$).
+    clip_value: Threshold for clipping gradients.
 
     # Returns
     Binarized tensor.
@@ -170,8 +170,8 @@ class SteSign(QuantizerFunctionWrapper):
     (essentially the binarization is replaced by a clipped identity on the
     backward pass).
     \\[\frac{\partial q(x)}{\partial x} = \begin{cases}
-      1 & \left|x\right| \leq t_\text{clip} \\\
-      0 & \left|x\right| > t_\text{clip}
+      1 & \left|x\right| \leq \texttt{clip_value} \\\
+      0 & \left|x\right| > \texttt{clip_value}
     \end{cases}\\]
 
     ```plot-activation
@@ -179,7 +179,7 @@ class SteSign(QuantizerFunctionWrapper):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients ($t_\text{clip}$).
+    clip_value: Threshold for clipping gradients.
 
     # References
     - [Binarized Neural Networks: Training Deep Neural Networks with Weights and
@@ -202,7 +202,7 @@ def magnitude_aware_sign(x, clip_value=1.0):
 
     # Arguments
     x: Input tensor
-    clip_value: Threshold for clipping gradients ($t_\text{clip}$).
+    clip_value: Threshold for clipping gradients.
 
     # Returns
     Scaled binarized tensor (with values in $\{-a, a\}$, where $a$ is a float).
@@ -227,7 +227,7 @@ class MagnitudeAwareSign(QuantizerFunctionWrapper):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients ($t_\text{clip}$).
+    clip_value: Threshold for clipping gradients.
 
     # References
     - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
@@ -305,8 +305,8 @@ def ste_tern(x, threshold_value=0.05, ternary_weight_networks=False, clip_value=
     (essentially the Ternarization is replaced by a clipped identity on the
     backward pass).
     \\[\frac{\partial q(x)}{\partial x} = \begin{cases}
-    1 & \left|x\right| \leq t_\text{clip} \\\
-    0 & \left|x\right| > t_\text{clip}
+    1 & \left|x\right| \leq \texttt{clip_value} \\\
+    0 & \left|x\right| > \texttt{clip_value}
     \end{cases}\\]
 
     ```plot-activation
@@ -318,7 +318,7 @@ def ste_tern(x, threshold_value=0.05, ternary_weight_networks=False, clip_value=
     threshold_value: The value for the threshold, $\Delta$.
     ternary_weight_networks: Boolean of whether to use the
         Ternary Weight Networks threshold calculation.
-    clip_value: Threshold for clipping gradients ($t_\text{clip}$).
+    clip_value: Threshold for clipping gradients.
 
     # Returns
     Ternarized tensor.
@@ -364,8 +364,8 @@ class SteTern(QuantizerFunctionWrapper):
     (essentially the Ternarization is replaced by a clipped identity on the
     backward pass).
     \\[\frac{\partial q(x)}{\partial x} = \begin{cases}
-    1 & \left|x\right| \leq t_\text{clip} \\\
-    0 & \left|x\right| > t_\text{clip}
+    1 & \left|x\right| \leq \texttt{clip_value} \\\
+    0 & \left|x\right| > \texttt{clip_value}
     \end{cases}\\]
 
     ```plot-activation
@@ -376,7 +376,7 @@ class SteTern(QuantizerFunctionWrapper):
     threshold_value: The value for the threshold, $\Delta$.
     ternary_weight_networks: Boolean of whether to use the
         Ternary Weight Networks threshold calculation.
-    clip_value: Threshold for clipping gradients ($t_\text{clip}$).
+    clip_value: Threshold for clipping gradients.
 
     # References
     - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -34,7 +34,7 @@ other two formulations, intermediate layers - like batch normalization or
 average pooling - and shortcut connections may result in non-binary input
 to the convolutions.
 
-Quantizers can eighter be referenced by string or called directly.
+Quantizers can either be referenced by string or called directly.
 The following usages are equivalent:
 
 ```python

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -23,7 +23,14 @@ def test_serialization(module, name):
     assert type(fn.precision) == int
 
 
-@pytest.mark.parametrize("ref_fn", [lq.quantizers.SteTern()])
+@pytest.mark.parametrize(
+    "ref_fn",
+    [
+        lq.quantizers.SteSign(),
+        lq.quantizers.MagnitudeAwareSign(),
+        lq.quantizers.SteTern(),
+    ],
+)
 def test_serialization_cls(ref_fn):
     assert type(ref_fn.precision) == int
     config = lq.quantizers.serialize(ref_fn)


### PR DESCRIPTION
This adds the possibility to configure gradient clipping for the quantizers since it is a hyperparameter that changes the training.

~~Note: This PR is built on-top of #181.~~ rebased onto master and ready to be merged