### PR TITLE
Format numbers in larq model summaries to be more readable. Closes #192.

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -51,7 +51,7 @@ def _bitsize_as_str(bitsize):
 def _number_as_readable_str(num):
     # The initial rounding here is necessary so that e.g. `999000` gets
     # formatted as `1.000 M` rather than `1000 k`
-    num = float("{:.3g}".format(num))
+    num = float(f"{num:.3g}")
 
     # For numbers less than 1000, output them directly, stripping any trailing
     # zeros and decimal places.
@@ -61,7 +61,7 @@ def _number_as_readable_str(num):
     # For numbers that are at least 1000 trillion (1 quadrillion) format with
     # scientific notation (3 s.f. = 2 d.p. in scientific notation).
     if num >= 1e15:
-        return "{:#.2E}".format(num)
+        return f"{num:#.2E}"
 
     # Count the magnitude.
     magnitude = 0
@@ -71,7 +71,7 @@ def _number_as_readable_str(num):
 
     # ':#.3g' formats the number with 3 significant figures, without stripping
     # trailing zeros.
-    num = "{:#.3g}".format(num).rstrip(".")
+    num = f"{num:#.3g}".rstrip(".")
     unit = ["", " k", " M", " B", " T"][magnitude]
     return num + unit
 

--- a/larq/models.py
+++ b/larq/models.py
@@ -48,6 +48,31 @@ def _bitsize_as_str(bitsize):
         raise NotImplementedError()
 
 
+def _number_as_readable_str(num):
+    # The initial rounding here is necessary so that e.g. `999000` gets
+    # formatted as `1.000 M` rather than `1000 k`
+    num = float("{:.4g}".format(num))
+
+    # For numbers that are at least 1000 trillion (1 quadrillion) format with
+    # scientific notation.
+    if num >= 1e15:
+        return "{:#.3E}".format(num)
+
+    # Count the magnitude.
+    magnitude = 0
+    while abs(num) >= 1000 and magnitude < 4:
+        magnitude += 1
+        num /= 1000.0
+
+    # ':#.4g' formats the number with 4 significant figures, without stripping
+    # trailing zeros.
+    num = "{:#.4g}".format(num)
+    unit = ["", " k", " M", " B", " T"][magnitude]
+
+    # The `rstrip`s ensure that integers < 1000 get formatted as-is.
+    return (num + unit).rstrip("0").rstrip(".")
+
+
 def _format_table_entry(x, units=1):
     try:
         assert not np.isnan(x)
@@ -295,9 +320,15 @@ class ModelProfile(LayerProfile):
 
     def generate_summary(self, include_macs=True):
         summary = [
-            ["Total params", self.weight_count()],
-            ["Trainable params", self.weight_count(trainable=True)],
-            ["Non-trainable params", self.weight_count(trainable=False)],
+            ["Total params", _number_as_readable_str(self.weight_count())],
+            [
+                "Trainable params",
+                _number_as_readable_str(self.weight_count(trainable=True)),
+            ],
+            [
+                "Non-trainable params",
+                _number_as_readable_str(self.weight_count(trainable=False)),
+            ],
             ["Model size:", f"{self.memory / (8*1024*1024):.2f} MB"],
             [
                 "Float-32 Equivalent",
@@ -309,7 +340,12 @@ class ModelProfile(LayerProfile):
         if include_macs:
             binarization_ratio = self.op_count("mac", 1) / self.op_count(op_type="mac")
             ternarization_ratio = self.op_count("mac", 2) / self.op_count(op_type="mac")
-            summary.append(["Number of MACs", self.op_count(op_type="mac")])
+            summary.append(
+                [
+                    "Number of MACs",
+                    _number_as_readable_str(self.op_count(op_type="mac")),
+                ]
+            )
             if binarization_ratio > 0:
                 summary.append(
                     ["Ratio of MACs that are binarized", f"{binarization_ratio:.4f}"]

--- a/larq/models.py
+++ b/larq/models.py
@@ -51,12 +51,17 @@ def _bitsize_as_str(bitsize):
 def _number_as_readable_str(num):
     # The initial rounding here is necessary so that e.g. `999000` gets
     # formatted as `1.000 M` rather than `1000 k`
-    num = float("{:.4g}".format(num))
+    num = float("{:.3g}".format(num))
+
+    # For numbers less than 1000, output them directly, stripping any trailing
+    # zeros and decimal places.
+    if num < 1000:
+        return str(num).rstrip("0").rstrip(".")
 
     # For numbers that are at least 1000 trillion (1 quadrillion) format with
-    # scientific notation.
+    # scientific notation (3 s.f. = 2 d.p. in scientific notation).
     if num >= 1e15:
-        return "{:#.3E}".format(num)
+        return "{:#.2E}".format(num)
 
     # Count the magnitude.
     magnitude = 0
@@ -64,13 +69,11 @@ def _number_as_readable_str(num):
         magnitude += 1
         num /= 1000.0
 
-    # ':#.4g' formats the number with 4 significant figures, without stripping
+    # ':#.3g' formats the number with 3 significant figures, without stripping
     # trailing zeros.
-    num = "{:#.4g}".format(num)
+    num = "{:#.3g}".format(num).rstrip(".")
     unit = ["", " k", " M", " B", " T"][magnitude]
-
-    # The `rstrip`s ensure that integers < 1000 get formatted as-is.
-    return (num + unit).rstrip("0").rstrip(".")
+    return num + unit
 
 
 def _format_table_entry(x, units=1):

--- a/larq/snapshots/snap_models_test.py
+++ b/larq/snapshots/snap_models_test.py
@@ -21,13 +21,13 @@ snapshots['test_summary 1'] = '''+sequential stats------------------------------
 | Total                                                     1600      288     38794  151.80       19.38        4.25       148.73 |
 +--------------------------------------------------------------------------------------------------------------------------------+
 +sequential summary--------------------------+
-| Total params                       40.68 k |
-| Trainable params                   1.952 k |
-| Non-trainable params               38.73 k |
+| Total params                       40.7 k  |
+| Trainable params                   1.95 k  |
+| Non-trainable params               38.7 k  |
 | Model size:                        0.15 MB |
 | Float-32 Equivalent                0.16 MB |
 | Compression Ratio of Memory        0.96    |
-| Number of MACs                     1.412 M |
+| Number of MACs                     1.41 M  |
 | Ratio of MACs that are binarized   0.1124  |
 | Ratio of MACs that are ternarized  0.0247  |
 +--------------------------------------------+

--- a/larq/snapshots/snap_models_test.py
+++ b/larq/snapshots/snap_models_test.py
@@ -21,13 +21,13 @@ snapshots['test_summary 1'] = '''+sequential stats------------------------------
 | Total                                                     1600      288     38794  151.80       19.38        4.25       148.73 |
 +--------------------------------------------------------------------------------------------------------------------------------+
 +sequential summary--------------------------+
-| Total params                       40682   |
-| Trainable params                   1952    |
-| Non-trainable params               38730   |
+| Total params                       40.68 k |
+| Trainable params                   1.952 k |
+| Non-trainable params               38.73 k |
 | Model size:                        0.15 MB |
 | Float-32 Equivalent                0.16 MB |
 | Compression Ratio of Memory        0.96    |
-| Number of MACs                     1411968 |
+| Number of MACs                     1.412 M |
 | Ratio of MACs that are binarized   0.1124  |
 | Ratio of MACs that are ternarized  0.0247  |
 +--------------------------------------------+


### PR DESCRIPTION
An example approach that formats numbers with three-significant figures and a magnitude (e.g. `k`, `M`, `B`, et cetera). This works for all numbers up to ~999 trillion. For larger numbers, scientific notation is used.

Illustrative examples:

```
>>> for i in range(1, 20):
...     num = int("1234567890123456789"[:i])
...     print("Number:", num, " " * (20 - i), "Formatted:", _number_as_readable_str(num))
...
Number: 1                     Formatted: 1
Number: 12                    Formatted: 12
Number: 123                   Formatted: 123
Number: 1234                  Formatted: 1.23 k
Number: 12345                 Formatted: 12.3 k
Number: 123456                Formatted: 123 k
Number: 1234567               Formatted: 1.23 M
Number: 12345678              Formatted: 12.3 M
Number: 123456789             Formatted: 123 M
Number: 1234567890            Formatted: 1.23 B
Number: 12345678901           Formatted: 12.3 B
Number: 123456789012          Formatted: 123 B
Number: 1234567890123         Formatted: 1.23 T
Number: 12345678901234        Formatted: 12.3 T
Number: 123456789012345       Formatted: 123 T
Number: 1234567890123456      Formatted: 1.23E+15
Number: 12345678901234567     Formatted: 1.23E+16
Number: 123456789012345678    Formatted: 1.23E+17
Number: 1234567890123456789   Formatted: 1.23E+18

>>> for i in range(1, 20):
...     num = int("99999999999999999999"[:i])
...     print("Number:", num, " " * (20 - i), "Formatted:", _number_as_readable_str(num))
...
Number: 9                     Formatted: 9
Number: 99                    Formatted: 99
Number: 999                   Formatted: 999
Number: 9999                  Formatted: 10.0 k
Number: 99999                 Formatted: 100 k
Number: 999999                Formatted: 1.00 M
Number: 9999999               Formatted: 10.0 M
Number: 99999999              Formatted: 100 M
Number: 999999999             Formatted: 1.00 B
Number: 9999999999            Formatted: 10.0 B
Number: 99999999999           Formatted: 100 B
Number: 999999999999          Formatted: 1.00 T
Number: 9999999999999         Formatted: 10.0 T
Number: 99999999999999        Formatted: 100 T
Number: 999999999999999       Formatted: 1.00E+15
Number: 9999999999999999      Formatted: 1.00E+16
Number: 99999999999999999     Formatted: 1.00E+17
Number: 999999999999999999    Formatted: 1.00E+18
Number: 9999999999999999999   Formatted: 1.00E+19
```