### PR TITLE
Add docs formatter to automatically add netron links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,9 @@ markdown_extensions:
         - name: plot-altair
           class: larq-altair
           format: !!python/name:plot_altair.html_format
+        - name: netron
+          class: larq-netron
+          format: !!python/name:netron_link.html_format
   - pymdownx.arithmatex
   - toc:
       permalink: true

--- a/netron_link.py
+++ b/netron_link.py
@@ -1,0 +1,7 @@
+netron_link = "https://lutzroeder.github.io/netron"
+cors_proxy = "https://cors-anywhere.herokuapp.com"
+release_url = "https://github.com/larq/zoo/releases/download"
+
+
+def html_format(source, language, css_class, options, md):
+    return f'<a href="{netron_link}/?url={cors_proxy}/{release_url}/{source}">Interactive architecture diagram</a>'


### PR DESCRIPTION
This adds a formatter that automatically adds a link to the network architecture rendered by netron.
E.g.: [Interactive architecture diagram](https://lutzroeder.github.io/netron/?url=https://cors-anywhere.herokuapp.com/https://github.com/larq/zoo/releases/download/resnet_e-v0.1.0/resnet_e_18.json)
![Bildschirmfoto 2019-09-02 um 15 26 58](https://user-images.githubusercontent.com/13285808/64121444-c2e3ac80-cd96-11e9-8683-104a6e621fe3.png)
