### PR TITLE
Fix Tensor comparison to support TF2-rc0 hashing behaviour

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
           pytest.args: "--cov=larq --cov-report=html --cov-config=.coveragerc"
         Python37_TF2:
           python.version: "3.7"
-          tensorflow.version: "2.0.0-beta1"
+          tensorflow.version: "2.0.0-rc0"
 
     steps:
       - task: UsePythonVersion@0
@@ -33,7 +33,7 @@ jobs:
           pip install pytest-azurepipelines
         displayName: "Install dependencies"
 
-      - script: pytest . $(pytest.args)
+      - script: pytest . -vv $(pytest.args)
         displayName: "pytest"
 
   - job: "Lint"

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -48,8 +48,11 @@ class QuantizerBase(tf.keras.layers.Layer):
     def non_trainable_weights(self):
         weights = super().non_trainable_weights
         if hasattr(self, "flip_ratio"):
-            metrics_weights = self.flip_ratio.weights
-            return [weight for weight in weights if weight not in metrics_weights]
+            return [
+                weight
+                for weight in weights
+                if not any(weight is metric_w for metric_w in self.flip_ratio.weights)
+            ]
         return weights
 
     def call(self, inputs):
@@ -115,8 +118,11 @@ class QuantizerDepthwiseBase(tf.keras.layers.Layer):
     def non_trainable_weights(self):
         weights = super().non_trainable_weights
         if hasattr(self, "flip_ratio"):
-            metrics_weights = self.flip_ratio.weights
-            return [weight for weight in weights if weight not in metrics_weights]
+            return [
+                weight
+                for weight in weights
+                if not any(weight is metric_w for metric_w in self.flip_ratio.weights)
+            ]
         return weights
 
     def call(self, inputs):
@@ -206,7 +212,11 @@ class QuantizerSeparableBase(tf.keras.layers.Layer):
         if hasattr(self, "pointwise_flip_ratio"):
             metrics_weights.extend(self.pointwise_flip_ratio.weights)
         if metrics_weights:
-            return [weight for weight in weights if weight not in metrics_weights]
+            return [
+                weight
+                for weight in weights
+                if not any(weight is metric_w for metric_w in metrics_weights)
+            ]
         return weights
 
     def call(self, inputs):

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -118,7 +118,7 @@ class FlipRatio(Metric):
 
     def reset_states(self):
         tf.keras.backend.batch_set_value(
-            [(v, 0) for v in self.variables if v != self._previous_values]
+            [(v, 0) for v in self.variables if v is not self._previous_values]
         )
 
     def get_config(self):

--- a/larq/models.py
+++ b/larq/models.py
@@ -131,7 +131,7 @@ class LayerProfile:
             WeightProfile(
                 weight,
                 self._get_bitwidth(weight),
-                trainable=weight in layer.trainable_weights,
+                trainable=any(weight is w for w in layer.trainable_weights),
             )
             for weight in layer.weights
         ]

--- a/larq/models.py
+++ b/larq/models.py
@@ -228,18 +228,16 @@ class LayerProfile:
 
         return row
 
-    def _quantized_weights(self):
-        try:
-            return self._layer.quantized_latent_weights
-        except:
-            return []
-
     def _get_bitwidth(self, weight):
         try:
-            quantizer = self._layer.quantizers[self._quantized_weights().index(weight)]
-            return quantizer.precision
+            for quantizer, quantized_weight in zip(
+                self._layer.quantizers, self._layer.quantized_latent_weights
+            ):
+                if quantized_weight is weight:
+                    return quantizer.precision
         except:
-            return 32
+            pass
+        return 32
 
 
 class ModelProfile(LayerProfile):


### PR DESCRIPTION
Recently TensorFlow changed the behaviour of equality in 2.0 such that Variables & Tensors are no longer hashable. This breaks our current strategy of Tensor comparison, since TF 2 now tries to compare elementwise. This PR fixes the comparison to account for the new behaviour.

For more info see https://github.com/tensorflow/tensorflow/issues/32210
Closes #195