### PR TITLE
Simplify string formatting

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -61,7 +61,7 @@ def _number_as_readable_str(num):
     # For numbers that are at least 1000 trillion (1 quadrillion) format with
     # scientific notation (3 s.f. = 2 d.p. in scientific notation).
     if num >= 1e15:
-        return f"{num:#.2E}"
+        return f"{num:.2E}"
 
     # Count the magnitude.
     magnitude = 0
@@ -71,7 +71,7 @@ def _number_as_readable_str(num):
 
     # ':#.3g' formats the number with 3 significant figures, without stripping
     # trailing zeros.
-    num = f"{num:#.3g}".rstrip(".")
+    num = f"{num:.3g}".rstrip(".")
     unit = ["", " k", " M", " B", " T"][magnitude]
     return num + unit
 


### PR DESCRIPTION
As far as I know, this shouldn't change functionallity, but removing the `#` fixes syntax highlighting inside my text editor.