### PR TITLE
Bump MathJax@3 Vega-Embed@5

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,10 +78,10 @@ markdown_extensions:
       permalink: true
 
 extra_javascript:
-  - "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_CHTML"
+  - "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
   - "https://cdn.jsdelivr.net/npm/vega@5"
   - "https://cdn.jsdelivr.net/npm/vega-lite@3"
-  - "https://cdn.jsdelivr.net/npm/vega-embed@4"
+  - "https://cdn.jsdelivr.net/npm/vega-embed@5"
 
 extra_css:
   - custom.css


### PR DESCRIPTION
[MathJax 3](https://github.com/mathjax/MathJax/releases/tag/3.0.0) is a complete rewrite and should improve our LaTeX rendering performance. Vega-Embed should've been at version 5 all along.