### PR TITLE
Add Dorefa quantizer

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -69,6 +69,7 @@ __all__ = [
     "ste_tern",
     "SteHeaviside",
     "ste_heaviside",
+    "DorefaQuantizer"
 ]
 
 
@@ -534,6 +535,61 @@ def ste_heaviside(x, clip_value=1.0):
         return tf.sign(tf.nn.relu(x)), grad
 
     return _and_binarize_with_identity_grad(x)
+
+
+
+def _dorefa_k_bit_quantizer(x, k_bit=2):
+    x = tf.clip_by_value(x, 0.0, 1.0)
+
+    @tf.custom_gradient
+    def _k_bit_with_identity_grad(x):
+        n = 2 ** k_bit - 1
+        return tf.round(x * n) / n, lambda dy: dy
+
+    return _k_bit_with_identity_grad(x)
+
+
+@utils.register_keras_custom_object
+class DorefaQuantizer(QuantizerFunctionWrapper):
+    r"""Instantiates a serializable k_bit quantizer as in the DoReFa paper.
+
+    \\[
+    q(x) = \begin{cases}
+    0 & x < \frac{1}{2n} \\\
+    \frac{i}{n} & \frac{2i-1}{2n} < |x| < \frac{2i+1}{2n} \text{ for } i \in \\{1,n-1\\}\\\
+     1 & \frac{2n-1}{2n} < x
+    \end{cases}
+    \\]
+
+    where \\(n = 2^{\text{k_bit}} - 1\\). The number of bits, k_bit, needs to be passed as an argument.
+    The gradient is estimated using the Straight-Through Estimator
+    (essentially the binarization is replaced by a clipped identity on the
+    backward pass).
+    \\[\frac{\partial q(x)}{\partial x} = \begin{cases}
+    1 &  0 \leq x \leq 1 \\\
+    0 & \text{else}
+    \end{cases}\\]
+    Note that in the original tensorpack implementation the clip and
+    the quantizer are two different functions that get composed.
+
+    ```plot-activation
+    quantizers._dorefa_k_bit_quantizer
+    ```
+
+    # Arguments
+    k_bit: number of bits for the quantization.
+
+    # Returns
+    Quantization function
+
+    # References
+    - [DoReFa-Net: Training Low Bitwidth Convolutional Neural Networks
+      with Low Bitwidth Gradients](https://arxiv.org/abs/1606.06160)
+    """
+
+    def __init__(self, k_bit):
+        super().__init__(_dorefa_k_bit_quantizer, k_bit=k_bit)
+        self.precision = k_bit
 
 
 def serialize(quantizer):

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -538,7 +538,7 @@ def ste_heaviside(x, clip_value=1.0):
     return _and_binarize_with_identity_grad(x)
 
 
-def dorefa_k_bit_quantizer(x, k_bit=2):
+def dorefa_quantizer(x, k_bit=2):
     r"""k_bit quantizer as in the DoReFa paper.
 
     \\[
@@ -559,7 +559,7 @@ def dorefa_k_bit_quantizer(x, k_bit=2):
     \end{cases}\\]
 
     ```plot-activation
-    quantizers.dorefa_k_bit_quantizer
+    quantizers.dorefa_quantizer
     ```
 
     # Arguments
@@ -604,7 +604,7 @@ class DoReFaQuantizer(QuantizerFunctionWrapper):
     \end{cases}\\]
     
     ```plot-activation
-    quantizers.dorefa_k_bit_quantizer
+    quantizers.dorefa_quantizer
     ```
 
     # Arguments
@@ -619,7 +619,7 @@ class DoReFaQuantizer(QuantizerFunctionWrapper):
     """
 
     def __init__(self, k_bit):
-        super().__init__(dorefa_k_bit_quantizer, k_bit=k_bit)
+        super().__init__(dorefa_quantizer, k_bit=k_bit)
         self.precision = k_bit
 
 

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -69,7 +69,7 @@ __all__ = [
     "ste_tern",
     "SteHeaviside",
     "ste_heaviside",
-    "DorefaQuantizer"
+    "DorefaQuantizer",
 ]
 
 
@@ -535,7 +535,6 @@ def ste_heaviside(x, clip_value=1.0):
         return tf.sign(tf.nn.relu(x)), grad
 
     return _and_binarize_with_identity_grad(x)
-
 
 
 def _dorefa_k_bit_quantizer(x, k_bit=2):

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -538,6 +538,8 @@ def ste_heaviside(x, clip_value=1.0):
     return _and_binarize_with_identity_grad(x)
 
 
+@utils.register_keras_custom_object
+@utils.set_precision(2)
 def dorefa_quantizer(x, k_bit=2):
     r"""k_bit quantizer as in the DoReFa paper.
 

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -215,7 +215,7 @@ def test_dorefa_quantize(fn):
     k_bit = 2
     n = 2 ** k_bit - 1
     assert not np.any(result > 1)
-    assert not np.any(result < -1)
+    assert not np.any(result < 0)
     for i in range(n + 1):
         assert np.all(
             result[(result > (2 * i - 1) / (2 * n)) & (result < (2 * i + 1) / (2 * n))]

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -205,7 +205,7 @@ def test_magnitude_aware_sign():
 
 
 @pytest.mark.parametrize(
-    "fn", [lq.quantizers._dorefa_k_bit_quantizer, lq.quantizers.DorefaQuantizer(2)]
+    "fn", [lq.quantizers.dorefa_quantizer, lq.quantizers.DoReFaQuantizer(2)]
 )
 def test_dorefa_quantize(fn):
     x = tf.keras.backend.placeholder(ndim=2)
@@ -234,6 +234,6 @@ def test_ste_grad_dorefa():
     x = np.random.uniform(-2, 2, (8, 3, 3, 16))
     tf_x = tf.Variable(x)
     with tf.GradientTape() as tape:
-        activation = lq.quantizers.DorefaQuantizer(2)(tf_x)
+        activation = lq.quantizers.DoReFaQuantizer(2)(tf_x)
     grad = tape.gradient(activation, tf_x)
     np.testing.assert_allclose(grad.numpy(), ste_grad(x))


### PR DESCRIPTION
This adds the k_bit quantizer from the DoReFa paper. https://arxiv.org/abs/1606.06160
The _dorefa_quantizer is a private function since I did not find an elegant way to set the precision dependent on the k_bit argument, so I think this function always be initialized with the DorefaQuantizer class where the precision is set dependent on this argument. 