### PR TITLE
Created CompatibilityMetric class, added register_alias decorator

### DIFF
--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -136,17 +136,17 @@ class FlipRatio(LarqMetric):
                 shape=values_shape,
                 dtype=self.values_dtype,
                 initializer=tf.keras.initializers.zeros,
-                aggregation=tf.VariableAggregation.SUM,
+                aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
             )
             self.total = self.add_weight(
                 "total",
                 initializer=tf.keras.initializers.zeros,
-                aggregation=tf.VariableAggregation.SUM,
+                aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
             )
             self.count = self.add_weight(
                 "count",
                 initializer=tf.keras.initializers.zeros,
-                aggregation=tf.VariableAggregation.SUM,
+                aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
             )
         self._size = np.prod(self.values_shape)
 

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -127,6 +127,7 @@ class FlipRatio(_CompatibilityMetric):
         super().__init__(name=name, dtype=dtype)
         self.values_dtype = tf.as_dtype(values_dtype)
         self.values_shape = tf.TensorShape(values_shape).as_list()
+        self.is_weight_metric = True
         with tf.init_scope():
             self._previous_values = self.add_weight(
                 "previous_values",

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 from larq import utils
 import numpy as np
+import tensorflow.keras.backend as K
 from contextlib import contextmanager
 
 try:
@@ -65,6 +66,13 @@ def get_training_metrics():
 class _CompatibilityMetric(Metric):
     r"""Metric with support for both 1.13 and 1.14+
     """
+
+    def get_config(self):
+        """Returns the serializable config of the metric."""
+        return {**super().get_config(), "name": self.name, "dtype": self.dtype}
+
+    def reset_states(self):
+        return K.batch_set_value([(v, 0) for v in self.variables])
 
     def add_weight(
         self,

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -64,7 +64,7 @@ def get_training_metrics():
 
 
 class _CompatibilityMetric(Metric):
-    r"""Metric with support for both 1.13 and 1.14+
+    """Metric with support for both 1.13 and 1.14+"""
     """
 
     def get_config(self):

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -65,9 +65,6 @@ def get_training_metrics():
 class LarqMetric(Metric):
     """Metric with support for both 1.13 and 1.14+"""
 
-    def reset_states(self):
-        return tf.keras.backend.batch_set_value([(v, 0) for v in self.variables])
-
     def add_weight(
         self,
         name,

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -72,7 +72,7 @@ class _CompatibilityMetric(Metric):
         return {**super().get_config(), "name": self.name, "dtype": self.dtype}
 
     def reset_states(self):
-        return K.batch_set_value([(v, 0) for v in self.variables])
+        return tf.keras.backend.batch_set_value([(v, 0) for v in self.variables])
 
     def add_weight(
         self,

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 from larq import utils
 import numpy as np
-import tensorflow.keras.backend as K
 from contextlib import contextmanager
 
 try:
@@ -63,13 +62,8 @@ def get_training_metrics():
     return _GLOBAL_TRAINING_METRICS
 
 
-class _CompatibilityMetric(Metric):
+class LarqMetric(Metric):
     """Metric with support for both 1.13 and 1.14+"""
-    """
-
-    def get_config(self):
-        """Returns the serializable config of the metric."""
-        return {**super().get_config(), "name": self.name, "dtype": self.dtype}
 
     def reset_states(self):
         return tf.keras.backend.batch_set_value([(v, 0) for v in self.variables])
@@ -110,7 +104,7 @@ class _CompatibilityMetric(Metric):
 
 @utils.register_alias("flip_ratio")
 @utils.register_keras_custom_object
-class FlipRatio(_CompatibilityMetric):
+class FlipRatio(LarqMetric):
     """Computes the mean ration of changed values in a given tensor.
 
     !!! example

--- a/larq/utils.py
+++ b/larq/utils.py
@@ -10,6 +10,23 @@ def register_keras_custom_object(cls):
     return cls
 
 
+def register_alias(name):
+    """A decorator to register a custom keras object under a given alias.
+    !!! example
+        ```python
+        @utils.register_alias("degeneration")
+        class Degeneration(tf.keras.metrics.Metric):
+            pass
+        ```
+    """
+
+    def register_func(cls):
+        get_custom_objects()[name] = cls
+        return cls
+
+    return register_func
+
+
 def tf_1_14_or_newer():
     return LooseVersion(tf.__version__) >= LooseVersion("1.14.0")
 


### PR DESCRIPTION
CompatibilityMetric will be the parent class of all our custom metrics. I added a register_alias decorator and registered the FlipRatio under flip_ratio, such that we can find it with tf.keras.metrics.get() in the future.