### PR TITLE
Add option to use unclipped identity STE in quantizers

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -146,7 +146,7 @@ def ste_sign(x, clip_value=1.0):
 
     # Arguments
     x: Input tensor.
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # Returns
     Binarized tensor.
@@ -186,7 +186,7 @@ class SteSign(QuantizerFunctionWrapper):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # References
     - [Binarized Neural Networks: Training Deep Neural Networks with Weights and
@@ -213,7 +213,7 @@ def magnitude_aware_sign(x, clip_value=1.0):
 
     # Arguments
     x: Input tensor
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # Returns
     Scaled binarized tensor (with values in \\(\\{-a, a\\}\\), where $a$ is a float).
@@ -238,7 +238,7 @@ class MagnitudeAwareSign(QuantizerFunctionWrapper):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # References
     - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
@@ -384,7 +384,7 @@ def ste_tern(x, threshold_value=0.05, ternary_weight_networks=False, clip_value=
     threshold_value: The value for the threshold, $\Delta$.
     ternary_weight_networks: Boolean of whether to use the
         Ternary Weight Networks threshold calculation.
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # Returns
     Ternarized tensor.
@@ -443,7 +443,7 @@ class SteTern(QuantizerFunctionWrapper):
     threshold_value: The value for the threshold, $\Delta$.
     ternary_weight_networks: Boolean of whether to use the
         Ternary Weight Networks threshold calculation.
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # References
     - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
@@ -485,7 +485,7 @@ class SteHeaviside(QuantizerFunctionWrapper):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # Returns
     AND Binarization function
@@ -523,7 +523,7 @@ def ste_heaviside(x, clip_value=1.0):
 
     # Arguments
     x: Input tensor.
-    clip_value: Threshold for clipping gradients.
+    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # Returns
     AND-binarized tensor.

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -156,7 +156,8 @@ def ste_sign(x, clip_value=1.0):
       Activations Constrained to +1 or -1](http://arxiv.org/abs/1602.02830)
     """
 
-    x = tf.clip_by_value(x, -clip_value, clip_value)
+    if clip_value is not None:
+        x = tf.clip_by_value(x, -clip_value, clip_value)
 
     return _binarize_with_identity_grad(x)
 
@@ -391,7 +392,8 @@ def ste_tern(x, threshold_value=0.05, ternary_weight_networks=False, clip_value=
     # References
     - [Ternary Weight Networks](http://arxiv.org/abs/1605.04711)
     """
-    x = tf.clip_by_value(x, -clip_value, clip_value)
+    if clip_value is not None:
+        x = tf.clip_by_value(x, -clip_value, clip_value)
 
     if ternary_weight_networks:
         threshold = 0.7 * tf.reduce_sum(tf.abs(x)) / tf.cast(tf.size(x), x.dtype)
@@ -526,7 +528,8 @@ def ste_heaviside(x, clip_value=1.0):
     # Returns
     AND-binarized tensor.
     """
-    x = tf.clip_by_value(x, -clip_value, clip_value)
+    if clip_value is not None:
+        x = tf.clip_by_value(x, -clip_value, clip_value)
 
     @tf.custom_gradient
     def _and_binarize_with_identity_grad(x):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -130,7 +130,7 @@ def test_ternarization_with_ternary_weight_networks():
     "fn", [lq.quantizers.ste_sign, lq.quantizers.ste_tern, lq.quantizers.ste_heaviside]
 )
 @pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_ste_grad(fn):
+def test_identity_ste_grad(fn):
     @np.vectorize
     def constant_grad(x):
         return 1.0
@@ -147,7 +147,7 @@ def test_ste_grad(fn):
     "fn", [lq.quantizers.ste_sign, lq.quantizers.ste_tern, lq.quantizers.ste_heaviside]
 )
 @pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_identity_ste_grad(fn):
+def test_ste_grad(fn):
     @np.vectorize
     def ste_grad(x):
         if np.abs(x) <= 1:

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -132,6 +132,23 @@ def test_ternarization_with_ternary_weight_networks():
 @pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
 def test_ste_grad(fn):
     @np.vectorize
+    def constant_grad(x):
+        return 1.0
+
+    x = np.random.uniform(-5, 5, (8, 3, 3, 16))
+    tf_x = tf.Variable(x)
+    with tf.GradientTape() as tape:
+        activation = fn(tf_x, clip_value=None)
+    grad = tape.gradient(activation, tf_x)
+    np.testing.assert_allclose(grad.numpy(), constant_grad(x))
+
+
+@pytest.mark.parametrize(
+    "fn", [lq.quantizers.ste_sign, lq.quantizers.ste_tern, lq.quantizers.ste_heaviside]
+)
+@pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
+def test_identity_ste_grad(fn):
+    @np.vectorize
     def ste_grad(x):
         if np.abs(x) <= 1:
             return 1.0


### PR DESCRIPTION
This will add the option for using a non clipped STE in all quantizers where it makes sense.