### PR TITLE
Add missing binder dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
-tensorflow==1.14.*
-matplotlib>=3.0.3
+tensorflow==1.14.0
+tensorflow_datasets==1.2.0
+larq_zoo==0.4.1
+Pillow==6.1.0
+matplotlib==3.1.1
+gast==0.2.2  # See https://github.com/tensorflow/tensorflow/issues/32319


### PR DESCRIPTION
This makes sure that https://larq.dev/models/examples/ can be executed properly on [Binder](https://mybinder.org)