### PR TITLE
Change "Why Larq?" menu item to "About"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
       - Papers using Larq: papers.md
       - Contributing Guide: contributing.md
       - Code of Conduct: code-of-conduct.md
-  - Why Larq?:
+  - About:
       - About: about.md
       - FAQ: faq.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ nav:
       - Contributing Guide: contributing.md
       - Code of Conduct: code-of-conduct.md
   - About:
-      - About: about.md
+      - Why Larq?: about.md
       - FAQ: faq.md
 
 repo_url: https://github.com/larq/larq


### PR DESCRIPTION
Having a FAQ under "Why Larq?" is not really intuitive. I think changing the heading to "About" makes sense or should we name it differently?