### PR TITLE
General clarification of Key concepts page

### DIFF
--- a/docs/guides/key-concepts.md
+++ b/docs/guides/key-concepts.md
@@ -34,7 +34,7 @@ A quantized layer computes activations \(\boldsymbol{y}\) as:
 \boldsymbol{y} = \sigma(f(q_{\, \mathrm{kernel}}(\boldsymbol{w}), q_{\, \mathrm{input}}(\boldsymbol{x})) + b)
 \\]
 
-with full precision weights \(\boldsymbol{w}\), arbitrary precision input \(\boldsymbol{x}\), layer operation \(f\), activation \(\sigma\) and bias \(b\). 
+with full precision weights \(\boldsymbol{w}\), arbitrary precision input \(\boldsymbol{x}\), layer operation \(f\), activation function \(\sigma\) and bias \(b\). 
 For a densely-connected layer \(f(\boldsymbol{w}, \boldsymbol{x}) = \boldsymbol{x}^T \boldsymbol{w}\).
 This computation will result in the following computational graph:
 

--- a/docs/guides/key-concepts.md
+++ b/docs/guides/key-concepts.md
@@ -28,7 +28,7 @@ In the documentation for each quantizer you will find the definition and a graph
 Each [quantized layer](https://larq.dev/api/layers/) accepts an `input_quantizer` and a `kernel_quantizer` that describe the way of quantizing the incoming activations and weights of the layer respectively. 
 If both `input_quantizer` and `kernel_quantizer` are `None` the layer is equivalent to a full precision layer.
 
-A quantized layer computes
+A quantized layer computes activations \(\boldsymbol{y}\) as:
 
 \\[
 \boldsymbol{y} = \sigma(f(q_{\, \mathrm{kernel}}(\boldsymbol{w}), q_{\, \mathrm{input}}(\boldsymbol{x})) + b)


### PR DESCRIPTION
Reading the documentation should follow the cognitive flow of the user. 
There were several issues. Examples: Quantization was not defined and directly after used in multiple senses (the concept and the `larq` implementation), which are not identical and the last section refers to QNN, without naming it first.

Some of the proposed changes are style preferences. Feel free to use any of the suggestions.