### PR TITLE
Extend example on front page and remove it from user guide

### DIFF
--- a/docs/guides/key-concepts.md
+++ b/docs/guides/key-concepts.md
@@ -103,58 +103,6 @@ x_binarized = larq.quantizers.ste_sign(x)
 x_binarized = tf.keras.layers.Activation("ste_sign")(x)
 ```
 
-### Defining a simple Binarized Neural Network
-A simple fully-connected Binarized Neural Network (BNN) using the [Straight-Through Estimator](https://larq.dev/api/quantizers/#ste_sign) can be defined in just a few lines of code using either the Keras sequential, functional or model subclassing APIs:
-
-```python tab="Larq 1-bit model"
-model = tf.keras.models.Sequential([
-    tf.keras.layers.Flatten(),
-    larq.layers.QuantDense(512,
-                           kernel_quantizer="ste_sign",
-                           kernel_constraint="weight_clip"),
-    larq.layers.QuantDense(10,
-                           input_quantizer="ste_sign",
-                           kernel_quantizer="ste_sign",
-                           kernel_constraint="weight_clip",
-                           activation="softmax")])
-```
-
-```python tab="Larq 1-bit model functional"
-x = tf.keras.Input(shape=(28, 28, 1))
-y = tf.keras.layers.Flatten()(x)
-y = larq.layers.QuantDense(512,
-                           kernel_quantizer="ste_sign",
-                           kernel_constraint="weight_clip")(y)
-y = larq.layers.QuantDense(10,
-                           input_quantizer="ste_sign",
-                           kernel_quantizer="ste_sign",
-                           kernel_constraint="weight_clip",
-                           activation="softmax")(y)
-model = tf.keras.Model(inputs=x, outputs=y)
-```
-
-```python tab="Larq 1-bit model subclassing"
-class MyModel(tf.keras.Model):
-    def __init__(self):
-        super().__init__()
-        self.flatten = tf.keras.layers.Flatten()
-        self.dense1 = larq.layers.QuantDense(512,
-                                             kernel_quantizer="ste_sign",
-                                             kernel_constraint="weight_clip")
-        self.dense2 = larq.layers.QuantDense(10,
-                                             input_quantizer="ste_sign",
-                                             kernel_quantizer="ste_sign",
-                                             kernel_constraint="weight_clip",
-                                             activation="softmax")
-
-    def call(self, inputs):
-        x = self.flatten(inputs)
-        x = self.dense1(x)
-        return self.dense2(x)
-
-model = MyModel()
-```
-
 ## Using Custom Quantizers
 
 Quantizers are functions that transform a full-precision input to a quantized output.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,15 @@ Existing deep neural networks use 32 bits, 16 bits or 8 bits to encode each weig
 
 ## Getting Started
 
-To build a QNN, Larq introduces the concept of [quantized layers](https://larq.dev/api/layers/) and [quantizers](https://larq.dev/api/quantizers/). A quantizer defines the way of transforming a full precision input to a quantized output and the pseudo-gradient method used for the backwards pass. Each quantized layer requires an `input_quantizer` and a `kernel_quantizer` that describe the way of quantizing the incoming activations and weights of the layer respectively. If both `input_quantizer` and `kernel_quantizer` are `None` the layer is equivalent to a full precision layer.
+To build a QNN, Larq introduces the concept of [quantized layers](https://larq.dev/api/layers/) and [quantizers](https://larq.dev/api/quantizers/). A quantizer defines the way of transforming a full precision input to a quantized output and the pseudo-gradient method used for the backwards pass. Each quantized layer requires an `input_quantizer` and a `kernel_quantizer` that describe the way of quantizing the incoming activations and weights of the layer respectively. If both `input_quantizer` and `kernel_quantizer` are `None` the layer is equivalent to a full precision layer. This layer can be used inside a [Keras model](https://www.tensorflow.org/alpha/guide/keras/overview#sequential_model) or with a [custom training loop](https://www.tensorflow.org/alpha/guide/keras/overview#model_subclassing).
 
-You can define a simple binarized fully-connected Keras model using the [Straight-Through Estimator](https://larq.dev/api/quantizers/#ste_sign) the following way:
+For a detailed explanation checkout our [user guide](https://larq.dev/guides/key-concepts/).
 
-```python
+### Defining a simple BNN
+
+A simple fully-connected BNN using the [Straight-Through Estimator](https://larq.dev/api/quantizers/#ste_sign) can be defined in just a few lines of code using either the Keras sequential, functional or model subclassing APIs:
+
+```python tab="Larq 1-bit model"
 model = tf.keras.models.Sequential([
     tf.keras.layers.Flatten(),
     larq.layers.QuantDense(512,
@@ -23,7 +27,41 @@ model = tf.keras.models.Sequential([
                            activation="softmax")])
 ```
 
-This layer can be used inside a [Keras model](https://www.tensorflow.org/alpha/guide/keras/overview#sequential_model) or with a [custom training loop](https://www.tensorflow.org/alpha/guide/keras/overview#model_subclassing).
+```python tab="Larq 1-bit model functional"
+x = tf.keras.Input(shape=(28, 28, 1))
+y = tf.keras.layers.Flatten()(x)
+y = larq.layers.QuantDense(512,
+                           kernel_quantizer="ste_sign",
+                           kernel_constraint="weight_clip")(y)
+y = larq.layers.QuantDense(10,
+                           input_quantizer="ste_sign",
+                           kernel_quantizer="ste_sign",
+                           kernel_constraint="weight_clip",
+                           activation="softmax")(y)
+model = tf.keras.Model(inputs=x, outputs=y)
+```
+
+```python tab="Larq 1-bit model subclassing"
+class MyModel(tf.keras.Model):
+    def __init__(self):
+        super().__init__()
+        self.flatten = tf.keras.layers.Flatten()
+        self.dense1 = larq.layers.QuantDense(512,
+                                             kernel_quantizer="ste_sign",
+                                             kernel_constraint="weight_clip")
+        self.dense2 = larq.layers.QuantDense(10,
+                                             input_quantizer="ste_sign",
+                                             kernel_quantizer="ste_sign",
+                                             kernel_constraint="weight_clip",
+                                             activation="softmax")
+
+    def call(self, inputs):
+        x = self.flatten(inputs)
+        x = self.dense1(x)
+        return self.dense2(x)
+
+model = MyModel()
+```
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,10 @@
 <h1><img src="/images/logo.svg" alt="logo" width="450px" style="display: block; margin-left: auto; margin-right: auto"/></h1>
 
-Larq is an open-source deep learning library for training neural networks with extremely low-precision weights and activations, such as Binarized Neural Networks (BNNs)[^1].
+Larq is an open-source Python library for training neural networks with extremely low-precision weights and activations, such as Binarized Neural Networks (BNNs)[^1].
 
-Existing deep neural networks use 32 bits, 16 bits or 8 bits to encode each weight and activation, making them large, slow and power-hungry. This prohibits many applications in resource-constrained environments. Larq is the first step towards solving this. It is designed to provide an easy to use, composable way to train BNNs (1 bit) and other types of Quantized Neural Networks (QNNs) and is based on the `tf.keras` interface.
+Existing deep neural networks use 32 bits, 16 bits or 8 bits to encode each weight and activation, making them large, slow and power-hungry. This prohibits many applications in resource-constrained environments. Larq is the first step towards solving this.
+The API of Larq is built on top of `tf.keras` and is designed to provide an easy to use, composable way to design and train BNNs (1 bit) and other types of Quantized Neural Networks (QNNs). It provides tools specifically designed to aid in BNN development, such as specialized optimizers, training metrics, and profiling tools.
+It is aimed at both researchers in the field of efficient deep learning and practitioners who want to explore BNNs for their applications. Furthermore, Larq makes it easier for beginners and students to get started with the field of efficient deep learning.
 
 ## Getting Started
 


### PR DESCRIPTION
This should make it easier to see what larq can do on the front page, without needing to find the user guide.
It also extends the first paragraph and adds some comments on the target audience.