### PR TITLE
Enforce PR labels

### DIFF
--- a/.github/pr_labels.yml
+++ b/.github/pr_labels.yml
@@ -1,0 +1,10 @@
+version: "1"
+invalidStatus: "pending"
+labelRule:
+  values:
+    - "bug"
+    - "documentation"
+    - "internal improvement"
+    - "performance"
+    - "dependencies"
+    - "feature"


### PR DESCRIPTION
This should make generation of release notes easier and makes sure all PRs are properly labeled.