### PR TITLE
Add Release Drafter as GH action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,8 @@
+template: |
+  ## Changes
+
+  $CHANGES
+
 categories:
   - title: ":warning: Breaking Changes :warning:"
     label: "breaking-change"
@@ -11,5 +16,6 @@ categories:
     label: "internal-improvement"
   - title: ":arrow_up: Dependencies"
     label: "dependencies"
+
 exclude-labels:
   - "skip-changelog"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,11 @@
+name: Release Notes
+
+on: [push]
+
+jobs:
+  update_draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should automatically draft release notes on once a PR is merged. For some reason the GitHub app didn't quite work.