### PR TITLE
Only run release notes action on pushed to master

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,4 @@
-template: |
-  ## Changes
-
-  $CHANGES
+template: $CHANGES
 
 categories:
   - title: ":warning: Breaking Changes :warning:"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,6 +1,9 @@
 name: Release Notes
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   update_draft_release:


### PR DESCRIPTION
This is hopefully the last PR that's needed to configure this bot correctly. Since the template is now setup correctly we could also use the GitHub app, but I think the GitHub action gives us more control (e.g. if we only want to run it when the tag is pushed).