### PR TITLE
Add explanation of scoped metric definition

### DIFF
--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -1,3 +1,10 @@
+"""We add metrics specific to extremely quantized networks using a `scope` rather than
+through the `metrics` parameter of `model.compile()`, where most common metrics reside.
+This is because, to calculate metrics like the `flip_ratio`, we need a layer's kernel or
+activation and not just the `y_true` and `y_pred` that Keras passes to metrics defined 
+in the usual way.
+"""
+
 import tensorflow as tf
 from larq import utils
 import numpy as np


### PR DESCRIPTION
Created top-level documentation for `larq/metrics.py`, explaining why we define the `flip_ratio` metric using a `scope` rather than passing it to the model at compile time. Based on pointers by @lgeiger.