### PR TITLE
Bump vega-embed@6

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ extra_javascript:
   - "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_CHTML"
   - "https://cdn.jsdelivr.net/npm/vega@5"
   - "https://cdn.jsdelivr.net/npm/vega-lite@3"
-  - "https://cdn.jsdelivr.net/npm/vega-embed@5"
+  - "https://cdn.jsdelivr.net/npm/vega-embed@6"
 
 extra_css:
   - custom.css


### PR DESCRIPTION
This brings us to the newest version of vega-embed used for rendering our interactive plots.