### PR TITLE
Update Release Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,15 +61,19 @@ We use [`black`](https://black.readthedocs.io/en/stable/) to format all of our c
 
 ## Publish release
 
-1. Increment the version number in `setup.py`, and commit the change.
+1. Increment the version number in `setup.py`, and make a PR with that change.
 
-2. Tag the commit (e.g. `v0.7.0`), and push the changes with the new tag.
+2. Wait until your PR is reviewed and merged.
+
+3. Create and push a new tag from the latest `master` branch (e.g. `v0.7.0`).
 
    ```shell
+   git checkout master
+   git pull
    git tag <version number>
-   git push && git push --tags
+   git push --tags
    ```
 
-3. Go to the [GitHub releases](https://github.com/larq/larq/releases) and publish the draft based on the tag you've just pushed and edit the release notes.
-
 4. A [GitHub action](https://github.com/larq/larq/actions) will automatically publish a release to [PyPI](https://pypi.org/) based on the tag.
+
+5. Go to the [GitHub releases](https://github.com/larq/larq/releases) and publish the draft based on the tag you've just pushed and edit the release notes.


### PR DESCRIPTION
The automatic PyPI release worked really well https://github.com/larq/larq/runs/259614586

This upgrade the release docs to clarify the new behaviour.