### PR TITLE
Cleanup lq.math tests

### DIFF
--- a/larq/activations_test.py
+++ b/larq/activations_test.py
@@ -2,6 +2,7 @@ import tensorflow as tf
 import numpy as np
 import pytest
 import larq as lq
+from larq.testing_utils import generate_real_values_with_zeros
 
 
 @pytest.mark.parametrize("name", ["hard_tanh", "leaky_tanh"])
@@ -15,7 +16,7 @@ def test_serialization(name):
 
 
 def test_hard_tanh():
-    real_values = np.random.uniform(-2, 2, (3, 3, 32))
+    real_values = generate_real_values_with_zeros()
     x = tf.keras.backend.placeholder(ndim=2)
     f = tf.keras.backend.function([x], [lq.activations.hard_tanh(x)])
     result = f([real_values])[0]
@@ -24,16 +25,16 @@ def test_hard_tanh():
 
 def test_leaky_tanh():
     @np.vectorize
-    def leaky_tanh(x):
+    def leaky_tanh(x, alpha):
         if x <= -1:
-            return -1 + 0.2 * (x + 1)
+            return -1 + alpha * (x + 1)
         elif x <= 1:
             return x
         else:
-            return 1 + 0.2 * (x - 1)
+            return 1 + alpha * (x - 1)
 
-    real_values = np.random.uniform(-2, 2, (3, 3, 32))
+    real_values = generate_real_values_with_zeros()
     x = tf.keras.backend.placeholder(ndim=2)
     f = tf.keras.backend.function([x], [lq.activations.leaky_tanh(x)])
     result = f([real_values])[0]
-    np.testing.assert_allclose(result, leaky_tanh(real_values))
+    np.testing.assert_allclose(result, leaky_tanh(real_values, alpha=0.2))

--- a/larq/constraints_test.py
+++ b/larq/constraints_test.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import tensorflow as tf
 import larq as lq
+from larq.testing_utils import generate_real_values_with_zeros
 
 
 @pytest.mark.parametrize("name", ["weight_clip"])
@@ -15,7 +16,7 @@ def test_serialization(name):
 
 
 def test_clip():
-    real_values = np.random.uniform(-2, 2, (3, 3, 32))
+    real_values = generate_real_values_with_zeros()
     clip_instance = lq.constraints.weight_clip(clip_value=0.75)
     result = clip_instance(tf.keras.backend.variable(real_values))
     result = tf.keras.backend.eval(result)

--- a/larq/math_test.py
+++ b/larq/math_test.py
@@ -1,16 +1,20 @@
 import tensorflow as tf
 import numpy as np
 import larq as lq
+from larq.testing_utils import generate_real_values_with_zeros
 
 
 def test_sign():
-    # test random
-    x = np.random.rand(100) * 100 - 0.5
-    y = lq.math.sign(x)
-    np.testing.assert_allclose(
-        tf.keras.backend.get_value(y), np.array(x >= 0, dtype=np.float32) * 2 - 1
-    )
-    # test zero is mapped to one
-    np.testing.assert_almost_equal(
-        tf.keras.backend.get_value(lq.math.sign(np.zeros(10))), np.array(np.ones(10))
-    )
+    binarized_values = np.random.choice([-1, 1], size=(2, 5)).astype(np.float32)
+    result = lq.math.sign(binarized_values)
+    np.testing.assert_allclose(result, binarized_values)
+
+    real_values = generate_real_values_with_zeros()
+    result = lq.math.sign(real_values)
+    assert not np.any(result == 0)
+    assert np.all(result[real_values < 0] == -1)
+    assert np.all(result[real_values >= 0] == 1)
+
+    zero_values = np.zeros((2, 5))
+    result = lq.math.sign(zero_values)
+    assert np.all(result == 1)

--- a/larq/math_test.py
+++ b/larq/math_test.py
@@ -1,4 +1,3 @@
-import tensorflow as tf
 import numpy as np
 import larq as lq
 from larq.testing_utils import generate_real_values_with_zeros

--- a/larq/math_test.py
+++ b/larq/math_test.py
@@ -1,19 +1,24 @@
 import numpy as np
 import larq as lq
 from larq.testing_utils import generate_real_values_with_zeros
+import pytest
+import tensorflow as tf
 
 
-def test_sign():
+@pytest.mark.parametrize("fn", [lq.math.sign])
+def test_sign(fn):
+    x = tf.keras.backend.placeholder(ndim=2)
+    f = tf.keras.backend.function([x], [fn(x)])
     binarized_values = np.random.choice([-1, 1], size=(2, 5)).astype(np.float32)
-    result = lq.math.sign(binarized_values)
+    result = f(binarized_values)[0]
     np.testing.assert_allclose(result, binarized_values)
 
     real_values = generate_real_values_with_zeros()
-    result = lq.math.sign(real_values)
+    result = f(real_values)[0]
     assert not np.any(result == 0)
     assert np.all(result[real_values < 0] == -1)
     assert np.all(result[real_values >= 0] == 1)
 
     zero_values = np.zeros((2, 5))
-    result = lq.math.sign(zero_values)
+    result = f(zero_values)[0]
     assert np.all(result == 1)

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import pytest
 import larq as lq
+from larq.testing_utils import generate_real_values_with_zeros
 
 
 @pytest.mark.parametrize("module", [lq.quantizers, tf.keras.activations])
@@ -46,12 +47,6 @@ def test_invalid_usage():
         lq.quantizers.get(42)
     with pytest.raises(ValueError):
         lq.quantizers.get("unknown")
-
-
-def generate_real_values_with_zeros(low=-2, high=2, shape=(4, 10)):
-    real_values = np.random.uniform(low, high, shape)
-    real_values = np.insert(real_values, 1, 0, axis=1)
-    return real_values
 
 
 @pytest.mark.parametrize(

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -7,6 +7,12 @@ from larq import utils
 from tensorflow.python.keras.testing_utils import _thread_local_data, should_run_eagerly
 
 
+def generate_real_values_with_zeros(low=-2, high=2, shape=(4, 10)):
+    real_values = np.random.uniform(low, high, shape)
+    real_values = np.insert(real_values, 1, 0, axis=1)
+    return real_values
+
+
 def get_small_bnn_model(input_dim, num_hidden, output_dim, trainable_bn=True):
     model = tf.keras.models.Sequential()
     model.add(


### PR DESCRIPTION
This PR touchs the math, activations and constraints test to bring them more inline with the quantizers tests.