### PR TITLE
Add google analytics tracking

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,10 @@ extra_javascript:
 extra_css:
   - custom.css
 
+google_analytics:
+  - "UA-144491780-1"
+  - "auto"
+
 plugins:
   - search
   - minify:


### PR DESCRIPTION
I disabled all adds features in Google analytics and [mkdocs material anonymises the IPs by default](https://github.com/squidfunk/mkdocs-material/blob/91f2289587c4340f1f8cb515ef3383ec9888757e/material/partials/integrations/analytics.html#L12) so we should be compliant with GDPR even without specifically asking users for permission.