### PR TITLE
Upgrade MathJax@3

### DIFF
--- a/docs/guides/bnn-optimization.md
+++ b/docs/guides/bnn-optimization.md
@@ -8,7 +8,7 @@ Stochastic Gradient Descent (SGD) is used pretty much everywhere in the field De
 
 However, when turning to BNNs, two fundamental issues arise with SGD:
 
-- The gradient of the binarization operation is zero almost everywhere, making the gradient $\frac{\partial L}{\partial w}$ utterly uninformative.
+- The gradient of the binarization operation is zero almost everywhere, making the gradient \\(\frac{\partial L}{\partial w}\\) utterly uninformative.
 - SGD performs optimization through small update steps that are accumulated over time. Binary weights, meanwhile, cannot absorb small updates: they can only be left alone or flipped.
 
 Another way of putting this is that the loss landscape for BNN is very different than what you are used to for real-valued networks. Gone are the glowing hills you can simply glide down from: the loss is now a discrete function, and many of the intuitions and theories developed for continuous loss landscapes no longer apply.
@@ -35,7 +35,7 @@ x_out = larq.layers.QuantDense(512,
                                kernel_constraint="weight_clip")(x_out)
 ```
 
-Any optimizer you now apply will update the latent weights; after the update the latent weights are clipped to $[-1, 1]$.
+Any optimizer you now apply will update the latent weights; after the update the latent weights are clipped to \\([-1, 1]\\).
 
 ### Alternative: Custom Optimizers
 

--- a/docs/guides/key-concepts.md
+++ b/docs/guides/key-concepts.md
@@ -5,12 +5,12 @@ Below, we summarize the key concepts you need to understand to work with BNNs.
 
 The transformation from high-precision Neural Networks to Quantized Neural Networks (QNNs) is achieved by [quantization](https://en.wikipedia.org/wiki/Quantization_(signal_processing)).
 This is the process of mapping a large set of, often continuous, values to a smaller countable set.
-Binarized Neural Networks are a special case of QNNs, where the quantization output \(x_q\) is binary:
+Binarized Neural Networks are a special case of QNNs, where the quantization output \\(x_q\\) is binary:
 \\[
 x_q = q(x), \quad x_q \in \\{-1, +1\\}, x \in \mathbb{R}
 \\]
 
-In `larq`, A [quantizer](https://larq.dev/api/quantizers/) \(q\) defines the way of transforming a full precision input to a quantized output and the pseudo-gradient method used for the backwards pass.
+In `larq`, A [quantizer](https://larq.dev/api/quantizers/) \\(q\\) defines the way of transforming a full precision input to a quantized output and the pseudo-gradient method used for the backwards pass.
 The latter is called pseudo-gradient, as it is in general not the true gradient.
 
 Generally, you will find quantizers throughout the network to quantize activations.
@@ -31,14 +31,14 @@ In the documentation for each quantizer you will find the definition and a graph
 Each [quantized layer](https://larq.dev/api/layers/) accepts an `input_quantizer` and a `kernel_quantizer` that describe the way of quantizing the incoming activations and weights of the layer respectively.
 If both `input_quantizer` and `kernel_quantizer` are `None` the layer is equivalent to a full precision layer.
 
-A quantized layer computes activations \(\boldsymbol{y}\) as:
+A quantized layer computes activations \\(\boldsymbol{y}\\) as:
 
 \\[
 \boldsymbol{y} = \sigma(f(q_{\, \mathrm{kernel}}(\boldsymbol{w}), q_{\, \mathrm{input}}(\boldsymbol{x})) + b)
 \\]
 
-with full precision weights \(\boldsymbol{w}\), arbitrary precision input \(\boldsymbol{x}\), layer operation \(f\), activation function \(\sigma\) and bias \(b\).
-For a densely-connected layer \(f(\boldsymbol{w}, \boldsymbol{x}) = \boldsymbol{x}^T \boldsymbol{w}\).
+with full precision weights \\(\boldsymbol{w}\\), arbitrary precision input \\(\boldsymbol{x}\\), layer operation \\(f\\), activation function \\(\sigma\\) and bias \\(b\\).
+For a densely-connected layer \\(f(\boldsymbol{w}, \boldsymbol{x}) = \boldsymbol{x}^T \boldsymbol{w}\\).
 This computation will result in the following computational graph:
 
 <div style="text-align:center;">

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -183,7 +183,7 @@ def magnitude_aware_sign(x, clip_value=1.0):
     clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
 
     # Returns
-    Scaled binarized tensor (with values in \\(\\{-a, a\\}\\), where $a$ is a float).
+    Scaled binarized tensor (with values in \\(\\{-a, a\\}\\), where \\(a\\) is a float).
 
     # References
     - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
@@ -297,13 +297,13 @@ def ste_tern(x, threshold_value=0.05, ternary_weight_networks=False, clip_value=
     \end{cases}
     \\]
 
-    where $\Delta$ is defined as the threshold and can be passed as an argument,
+    where \\(\Delta\\) is defined as the threshold and can be passed as an argument,
     or can be calculated as per the Ternary Weight Networks original paper, such that
 
     \\[
     \Delta = \frac{0.7}{n} \sum_{i=1}^{n} |W_i|
     \\]
-    where we assume that $W_i$ is generated from a normal distribution.
+    where we assume that \\(W_i\\) is generated from a normal distribution.
 
     The gradient is estimated using the Straight-Through Estimator
     (essentially the Ternarization is replaced by a clipped identity on the
@@ -319,7 +319,7 @@ def ste_tern(x, threshold_value=0.05, ternary_weight_networks=False, clip_value=
 
     # Arguments
     x: Input tensor.
-    threshold_value: The value for the threshold, $\Delta$.
+    threshold_value: The value for the threshold, \\(\Delta\\).
     ternary_weight_networks: Boolean of whether to use the
         Ternary Weight Networks threshold calculation.
     clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
@@ -577,13 +577,13 @@ class SteTern(QuantizerFunctionWrapper):
     \end{cases}
     \\]
 
-    where $\Delta$ is defined as the threshold and can be passed as an argument,
+    where \\(\Delta\\) is defined as the threshold and can be passed as an argument,
     or can be calculated as per the Ternary Weight Networks original paper, such that
 
     \\[
     \Delta = \frac{0.7}{n} \sum_{i=1}^{n} |W_i|
     \\]
-    where we assume that $W_i$ is generated from a normal distribution.
+    where we assume that \\(W_i\\) is generated from a normal distribution.
 
     The gradient is estimated using the Straight-Through Estimator
     (essentially the Ternarization is replaced by a clipped identity on the
@@ -598,7 +598,7 @@ class SteTern(QuantizerFunctionWrapper):
     ```
 
     # Arguments
-    threshold_value: The value for the threshold, $\Delta$.
+    threshold_value: The value for the threshold, \\(\Delta\\).
     ternary_weight_networks: Boolean of whether to use the
         Ternary Weight Networks threshold calculation.
     clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ markdown_extensions:
       permalink: true
 
 extra_javascript:
-  - "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_CHTML"
+  - "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
   - "https://cdn.jsdelivr.net/npm/vega@5"
   - "https://cdn.jsdelivr.net/npm/vega-lite@3"
   - "https://cdn.jsdelivr.net/npm/vega-embed@6"


### PR DESCRIPTION
This reverts #228 and fixes inconsistent MathJax syntax since MathJax 3 uses stricter defaults.
This should speedup our math rendering.