### PR TITLE
Use tf.test.TestCase instead of keras_parameterized

### DIFF
--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -1,6 +1,5 @@
 import tensorflow as tf
 from larq import metrics
-from tensorflow.python.keras import keras_parameterized
 import pytest
 
 
@@ -14,7 +13,7 @@ def test_scope():
             pass
 
 
-class FlipRatioTest(keras_parameterized.TestCase):
+class FlipRatioTest(tf.test.TestCase):
     def test_config(self):
         mcv = metrics.FlipRatio(
             values_shape=[3, 3], values_dtype="int16", name="mcv", dtype=tf.float16


### PR DESCRIPTION
This was added to fix some issues we had with different tests interfering with each other. This is now fixed since we use `pytest-xdist` to provide better isolation.