### PR TITLE
Add pytest fixture to run tests in eager and graph mode

### DIFF
--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+from tensorflow.python.eager import context
+
+
+@pytest.fixture
+def eager_mode():
+    """pytest fixture for running test in eager mode"""
+    with context.eager_mode():
+        yield
+
+
+@pytest.fixture
+def graph_mode():
+    """pytest fixture for running test in graph mode"""
+    with context.graph_mode():
+        yield
+
+
+@pytest.fixture(params=["eager", "graph"])
+def eager_and_graph_mode(request):
+    """pytest fixture for running test in eager and graph mode"""
+    with getattr(context, f"{request.param}_mode")():
+        yield request.param

--- a/larq/conftest_test.py
+++ b/larq/conftest_test.py
@@ -1,0 +1,16 @@
+import tensorflow as tf
+
+
+def test_eager_and_graph_mode_fixture(eager_and_graph_mode):
+    if eager_and_graph_mode == "eager":
+        assert tf.executing_eagerly()
+    else:
+        assert not tf.executing_eagerly()
+
+
+def test_eager_mode_fixture(eager_mode):
+    assert tf.executing_eagerly()
+
+
+def test_graph_mode_fixture(graph_mode):
+    assert not tf.executing_eagerly()

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -1,6 +1,5 @@
 import tensorflow as tf
 from larq import metrics
-from tensorflow.python.keras import keras_parameterized
 import pytest
 
 
@@ -14,70 +13,69 @@ def test_scope():
             pass
 
 
-class FlipRatioTest(keras_parameterized.TestCase):
-    def test_config(self):
-        mcv = metrics.FlipRatio(
-            values_shape=[3, 3], values_dtype="int16", name="mcv", dtype=tf.float16
+def test_config():
+    mcv = metrics.FlipRatio(
+        values_shape=[3, 3], values_dtype="int16", name="mcv", dtype=tf.float16
+    )
+    assert mcv.name == "mcv"
+    assert mcv.stateful
+    assert mcv.dtype == tf.float16
+    assert mcv.values_dtype == tf.int16
+    assert mcv.values_shape == [3, 3]
+
+    mcv2 = metrics.FlipRatio.from_config(mcv.get_config())
+    assert mcv2.name == "mcv"
+    assert mcv2.stateful
+    assert mcv2.dtype == tf.float16
+    assert mcv2.values_dtype == tf.int16
+    assert mcv2.values_shape == [3, 3]
+
+
+def test_metric(eager_mode):
+    mcv = metrics.FlipRatio([2])
+
+    assert 0 == mcv.result().numpy()
+    assert 0 == mcv.total.numpy()
+    assert 0 == mcv.count.numpy()
+
+    mcv.update_state([1, 1])
+    assert all([1, 1] == mcv._previous_values.numpy())
+    assert 0 == mcv.total.numpy()
+    assert 1 == mcv.count.numpy()
+    assert 0 == mcv.result().numpy()
+
+    mcv.update_state([2, 2])
+    assert all([2, 2] == mcv._previous_values.numpy())
+    assert 1 == mcv.total.numpy()
+    assert 2 == mcv.count.numpy()
+    assert 1 == mcv.result().numpy()
+
+    mcv.update_state([1, 2])
+    assert all([1, 2] == mcv._previous_values.numpy())
+    assert 1.5 == mcv.total.numpy()
+    assert 3 == mcv.count.numpy()
+    assert 1.5 / 2 == mcv.result().numpy()
+
+
+def test_metric_in_graph_mode(graph_mode):
+    mcv = metrics.FlipRatio([2])
+
+    new_state = tf.compat.v1.placeholder(dtype=tf.float32, shape=[2])
+    update_state_op = mcv.update_state(new_state)
+    metric_value = mcv.result()
+
+    with tf.compat.v1.Session() as sess:
+        sess.run(tf.compat.v1.variables_initializer(mcv.variables))
+
+        sess.run(update_state_op, feed_dict={new_state: [1, 1]})
+        sess.run(update_state_op, feed_dict={new_state: [2, 2]})
+        sess.run(update_state_op, feed_dict={new_state: [1, 2]})
+
+        previous, total, count, result = sess.run(
+            [mcv._previous_values, mcv.total, mcv.count, metric_value]
         )
-        self.assertEqual(mcv.name, "mcv")
-        self.assertTrue(mcv.stateful)
-        self.assertEqual(mcv.dtype, tf.float16)
-        self.assertEqual(mcv.values_dtype, tf.int16)
-        self.assertEqual(mcv.values_shape, [3, 3])
 
-        mcv2 = metrics.FlipRatio.from_config(mcv.get_config())
-        self.assertEqual(mcv2.name, "mcv")
-        self.assertTrue(mcv2.stateful)
-        self.assertEqual(mcv2.dtype, tf.float16)
-        self.assertEqual(mcv2.values_dtype, tf.int16)
-        self.assertEqual(mcv2.values_shape, [3, 3])
-
-    def test_metric(self):
-        mcv = metrics.FlipRatio([2])
-        self.evaluate(tf.compat.v1.variables_initializer(mcv.variables))
-
-        self.assertAllClose(0, mcv.result())
-        self.assertAllClose(0, self.evaluate(mcv.total))
-        self.assertAllClose(0, self.evaluate(mcv.count))
-
-        self.evaluate(mcv.update_state([1, 1]))
-        self.assertAllClose([1, 1], self.evaluate(mcv._previous_values))
-        self.assertAllClose(0, self.evaluate(mcv.total))
-        self.assertAllClose(1, self.evaluate(mcv.count))
-        self.assertAllClose(0, mcv.result())
-
-        self.evaluate(mcv.update_state([2, 2]))
-        self.assertAllClose([2, 2], self.evaluate(mcv._previous_values))
-        self.assertAllClose(1, self.evaluate(mcv.total))
-        self.assertAllClose(2, self.evaluate(mcv.count))
-        self.assertAllClose(1, mcv.result())
-
-        self.evaluate(mcv.update_state([1, 2]))
-        self.assertAllClose([1, 2], self.evaluate(mcv._previous_values))
-        self.assertAllClose(1.5, self.evaluate(mcv.total))
-        self.assertAllClose(3, self.evaluate(mcv.count))
-        self.assertAllClose(1.5 / 2, mcv.result())
-
-    @pytest.mark.skipif(tf.executing_eagerly(), reason="only applies to graph mode")
-    def test_metric_in_graph_mode(self):
-        mcv = metrics.FlipRatio([2])
-
-        new_state = tf.compat.v1.placeholder(dtype=tf.float32, shape=[2])
-        update_state_op = mcv.update_state(new_state)
-        metric_value = mcv.result()
-
-        with tf.compat.v1.Session() as sess:
-            sess.run(tf.compat.v1.variables_initializer(mcv.variables))
-
-            sess.run(update_state_op, feed_dict={new_state: [1, 1]})
-            sess.run(update_state_op, feed_dict={new_state: [2, 2]})
-            sess.run(update_state_op, feed_dict={new_state: [1, 2]})
-
-            previous, total, count, result = sess.run(
-                [mcv._previous_values, mcv.total, mcv.count, metric_value]
-            )
-
-        self.assertAllClose([1, 2], previous)
-        self.assertAllClose(1.5, total)
-        self.assertAllClose(3, count)
-        self.assertAllClose(1.5 / 2, result)
+    assert all([1, 2] == previous)
+    assert 1.5 == total
+    assert 3 == count
+    assert 1.5 / 2 == result

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -171,8 +171,7 @@ def test_ternarization_with_ternary_weight_networks():
 @pytest.mark.parametrize(
     "fn", [lq.quantizers.ste_sign, lq.quantizers.ste_tern, lq.quantizers.ste_heaviside]
 )
-@pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_identity_ste_grad(fn):
+def test_identity_ste_grad(eager_mode, fn):
     x = generate_real_values_with_zeros(shape=(8, 3, 3, 16))
     tf_x = tf.Variable(x)
     with tf.GradientTape() as tape:
@@ -184,8 +183,7 @@ def test_identity_ste_grad(fn):
 @pytest.mark.parametrize(
     "fn", [lq.quantizers.ste_sign, lq.quantizers.ste_tern, lq.quantizers.ste_heaviside]
 )
-@pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_ste_grad(fn):
+def test_ste_grad(eager_mode, fn):
     @np.vectorize
     def ste_grad(x):
         if np.abs(x) <= 1:
@@ -201,8 +199,7 @@ def test_ste_grad(fn):
 
 
 # Test with and without default threshold
-@pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_swish_grad():
+def test_swish_grad(eager_mode):
     def swish_grad(x, beta):
         return beta * (2 - beta * x * np.tanh(beta * x / 2)) / (1 + np.cosh(beta * x))
 
@@ -219,8 +216,7 @@ def test_swish_grad():
     np.testing.assert_allclose(grad.numpy(), swish_grad(x, beta=10.0))
 
 
-@pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_approx_sign_grad():
+def test_approx_sign_grad(eager_mode):
     @np.vectorize
     def approx_sign_grad(x):
         if np.abs(x) <= 1:
@@ -235,8 +231,7 @@ def test_approx_sign_grad():
     np.testing.assert_allclose(grad.numpy(), approx_sign_grad(x))
 
 
-@pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_magnitude_aware_sign():
+def test_magnitude_aware_sign(eager_mode):
     a = np.random.uniform(-2, 2, (3, 2, 2, 3))
     x = tf.Variable(a)
     with tf.GradientTape() as tape:
@@ -284,8 +279,7 @@ def test_dorefa_quantize(fn):
         )
 
 
-@pytest.mark.skipif(not tf.executing_eagerly(), reason="requires eager execution")
-def test_ste_grad_dorefa():
+def test_ste_grad_dorefa(eager_mode):
     @np.vectorize
     def ste_grad(x):
         if x <= 1 and x >= 0:


### PR DESCRIPTION
This should allow us to get rid of `tf.test.TestCase` and allow us to fully rely on `pytest` to execute tests in eager and graph mode. `tf.test.TestCase` doesn't play well with more advanced features of `pytest` so it makes sense to consolidate our testing setup to fully rely on `pytest`.