### PR TITLE
Refactor tests to not use TensorFlow TestCase

### DIFF
--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -23,9 +23,18 @@ def eager_and_graph_mode(request):
         yield request.param
 
 
-@pytest.fixture(params=["tf_eager", "tf_keras_eager", "graph"])
-def fixture_run_all_keras_modes(request):
-    """TODO"""
+@pytest.fixture(params=["graph", "tf_eager", "tf_keras_eager"])
+def keras_should_run_eagerly(request):
+    """Fixture to run in graph and two eager modes.
+    
+    The modes are:
+    - Graph mode
+    - TensorFlow eager and Keras eager
+    - TensorFlow eager and Keras not eager
+
+    The `tf.context` sets graph/eager mode for TensorFlow. The yield is True if Keras
+    should run eagerly.
+    """
 
     if request.param == "graph":
         with context.graph_mode():

--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import tensorflow as tf
 from tensorflow.python.eager import context
 
 
@@ -37,6 +38,9 @@ def keras_should_run_eagerly(request):
     """
 
     if request.param == "graph":
+        if int(tf.__version__[0]) >= 2:
+            pytest.skip("Skipping graph mode for TensorFlow 2+.")
+
         with context.graph_mode():
             yield
 

--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -27,7 +27,7 @@ def eager_and_graph_mode(request):
 @pytest.fixture(params=["graph", "tf_eager", "tf_keras_eager"])
 def keras_should_run_eagerly(request):
     """Fixture to run in graph and two eager modes.
-    
+
     The modes are:
     - Graph mode
     - TensorFlow eager and Keras eager
@@ -43,7 +43,6 @@ def keras_should_run_eagerly(request):
 
         with context.graph_mode():
             yield
-
     else:
         with context.eager_mode():
             yield request.param == "tf_keras_eager"

--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -21,3 +21,16 @@ def eager_and_graph_mode(request):
     """pytest fixture for running test in eager and graph mode"""
     with getattr(context, f"{request.param}_mode")():
         yield request.param
+
+
+@pytest.fixture(params=["tf_eager", "tf_keras_eager", "graph"])
+def fixture_run_all_keras_modes(request):
+    """TODO"""
+
+    if request.param == "graph":
+        with context.graph_mode():
+            yield
+
+    else:
+        with context.eager_mode():
+            yield request.param == "tf_keras_eager"

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -159,7 +159,7 @@ class LayersTest(keras_parameterized.TestCase):
 
 
 # TODO: Move back into class
-def test_depthwise_layers(fixture_run_all_keras_modes):
+def test_depthwise_layers(keras_should_run_eagerly):
     input_data = random_input((2, 3, 7, 6))
     random_weight = np.random.random() - 0.5
 
@@ -173,7 +173,7 @@ def test_depthwise_layers(fixture_run_all_keras_modes):
                 depthwise_initializer=tf.keras.initializers.constant(random_weight),
             ),
             input_data=input_data,
-            should_run_eagerly=fixture_run_all_keras_modes,
+            should_run_eagerly=keras_should_run_eagerly,
         )
 
     fp_output = testing_utils.layer_test(
@@ -185,7 +185,7 @@ def test_depthwise_layers(fixture_run_all_keras_modes):
             ),
         ),
         input_data=np.sign(input_data),
-        should_run_eagerly=fixture_run_all_keras_modes,
+        should_run_eagerly=keras_should_run_eagerly,
     )
 
     np.testing.assert_allclose(quant_output, fp_output)

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -1,11 +1,9 @@
 import tensorflow as tf
 import numpy as np
-from absl.testing import parameterized
 import larq as lq
 import pytest
 import inspect
 from larq import testing_utils
-from tensorflow.python.keras import keras_parameterized
 
 
 PARAMS_ALL_LAYERS = [

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -183,51 +183,47 @@ class TestLayers:
         np.testing.assert_allclose(quant_output, fp_output)
 
 
-def test_layer_warns(caplog):
-    lq.layers.QuantDense(5, kernel_quantizer="ste_sign")
-    assert len(caplog.records) >= 1
-    assert "kernel_constraint" in caplog.text
+class TestLayerWarns:
+    def test_layer_warns(self, caplog):
+        lq.layers.QuantDense(5, kernel_quantizer="ste_sign")
+        assert len(caplog.records) >= 1
+        assert "kernel_constraint" in caplog.text
 
+    def test_layer_does_not_warn(self, caplog):
+        lq.layers.QuantDense(
+            5, kernel_quantizer="ste_sign", kernel_constraint="weight_clip"
+        )
+        assert caplog.records == []
 
-def test_layer_does_not_warn(caplog):
-    lq.layers.QuantDense(
-        5, kernel_quantizer="ste_sign", kernel_constraint="weight_clip"
-    )
-    assert caplog.records == []
+    def test_depthwise_layer_warns(self, caplog):
+        lq.layers.QuantDepthwiseConv2D(5, depthwise_quantizer="ste_sign")
+        assert len(caplog.records) >= 1
+        assert "depthwise_constraint" in caplog.text
 
+    def test_depthwise_layer_does_not_warn(self, caplog):
+        lq.layers.QuantDepthwiseConv2D(
+            5, depthwise_quantizer="ste_sign", depthwise_constraint="weight_clip"
+        )
+        assert caplog.records == []
 
-def test_depthwise_layer_warns(caplog):
-    lq.layers.QuantDepthwiseConv2D(5, depthwise_quantizer="ste_sign")
-    assert len(caplog.records) >= 1
-    assert "depthwise_constraint" in caplog.text
+    def test_separable_layer_warns(self, caplog):
+        lq.layers.QuantSeparableConv2D(
+            3, 3, depthwise_quantizer="ste_sign", pointwise_quantizer="ste_sign"
+        )
+        assert len(caplog.records) == 2
+        assert "depthwise_constraint" in caplog.text
+        assert "pointwise_constraint" in caplog.text
 
-
-def test_depthwise_layer_does_not_warn(caplog):
-    lq.layers.QuantDepthwiseConv2D(
-        5, depthwise_quantizer="ste_sign", depthwise_constraint="weight_clip"
-    )
-    assert caplog.records == []
-
-
-def test_separable_layer_warns(caplog):
-    lq.layers.QuantSeparableConv2D(
-        3, 3, depthwise_quantizer="ste_sign", pointwise_quantizer="ste_sign"
-    )
-    assert len(caplog.records) == 2
-    assert "depthwise_constraint" in caplog.text
-    assert "pointwise_constraint" in caplog.text
-
-
-def test_separable_layer_does_not_warn(caplog):
-    lq.layers.QuantSeparableConv2D(
-        3,
-        3,
-        depthwise_quantizer="ste_sign",
-        pointwise_quantizer="ste_sign",
-        depthwise_constraint="weight_clip",
-        pointwise_constraint="weight_clip",
-    )
-    assert caplog.records == []
+    def test_separable_layer_does_not_warn(self, caplog):
+        lq.layers.QuantSeparableConv2D(
+            3,
+            3,
+            depthwise_quantizer="ste_sign",
+            pointwise_quantizer="ste_sign",
+            depthwise_constraint="weight_clip",
+            pointwise_constraint="weight_clip",
+        )
+        assert caplog.records == []
 
 
 def test_metrics():

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -2,9 +2,6 @@ import larq as lq
 import numpy as np
 import tensorflow as tf
 
-# We should find a better solution without relying on private objects
-from tensorflow.python.keras.testing_utils import _thread_local_data, should_run_eagerly
-
 
 def generate_real_values_with_zeros(low=-2, high=2, shape=(4, 10)):
     real_values = np.random.uniform(low, high, shape)

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -48,6 +48,7 @@ def layer_test(
     input_data=None,
     expected_output=None,
     expected_output_dtype=None,
+    should_run_eagerly=False,
 ):
     """Test routine for a layer with a single input and single output.
     Arguments:
@@ -148,17 +149,10 @@ def layer_test(
     # train(). This was causing some error for layer with Defun as it body.
     # See b/120160788 for more details. This should be mitigated after 2.0.
     model = tf.keras.models.Model(x, layer(x))
-    if _thread_local_data.run_eagerly is not None:
-        model.compile(
-            "rmsprop",
-            "mse",
-            weighted_metrics=["acc"],
-            run_eagerly=should_run_eagerly(),
-        )
-        model.train_on_batch(input_data, actual_output)
-    else:
-        model.compile("rmsprop", "mse", weighted_metrics=["acc"])
-        model.train_on_batch(input_data, actual_output)
+    model.compile(
+        "rmsprop", "mse", weighted_metrics=["acc"], run_eagerly=should_run_eagerly,
+    )
+    model.train_on_batch(input_data, actual_output)
 
     # test as first layer in Sequential API
     layer_config = layer.get_config()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "tensorflow": ["tensorflow>=1.14.0"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.14.0"],
         "test": [
-            "absl-py==0.8.1",
             "pytest==5.2.2",
             "pytest-cov==2.8.1",
             "pytest-xdist==1.30.0",


### PR DESCRIPTION
This consolidates our tests to all use `pytest.fixture` and `pytest.mark.parameterize`. Closes #314.