### PR TITLE
Simplify layer tests

### DIFF
--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from tensorflow.keras.initializers import constant as const_init
 import numpy as np
 import larq as lq
 import pytest
@@ -84,7 +83,7 @@ class TestLayers:
                     **kwargs,
                     kernel_quantizer="ste_sign",
                     input_quantizer="ste_sign",
-                    kernel_initializer=const_init(random_weight),
+                    kernel_initializer=tf.keras.initializers.constant(random_weight),
                 ),
                 input_data=input_data,
                 should_run_eagerly=keras_should_run_eagerly,
@@ -94,7 +93,9 @@ class TestLayers:
             [
                 layer(
                     **kwargs,
-                    kernel_initializer=const_init(np.sign(random_weight)),
+                    kernel_initializer=tf.keras.initializers.constant(
+                        np.sign(random_weight)
+                    ),
                     input_shape=input_shape[1:],
                 )
             ]
@@ -119,8 +120,12 @@ class TestLayers:
                     depthwise_quantizer="ste_sign",
                     pointwise_quantizer="ste_sign",
                     input_quantizer="ste_sign",
-                    depthwise_initializer=const_init(random_d_kernel),
-                    pointwise_initializer=const_init(random_p_kernel),
+                    depthwise_initializer=tf.keras.initializers.constant(
+                        random_d_kernel
+                    ),
+                    pointwise_initializer=tf.keras.initializers.constant(
+                        random_p_kernel
+                    ),
                 ),
                 input_data=input_data,
                 should_run_eagerly=keras_should_run_eagerly,
@@ -131,8 +136,12 @@ class TestLayers:
                 layer(
                     filters=3,
                     kernel_size=3,
-                    depthwise_initializer=const_init(np.sign(random_d_kernel)),
-                    pointwise_initializer=const_init(np.sign(random_p_kernel)),
+                    depthwise_initializer=tf.keras.initializers.constant(
+                        np.sign(random_d_kernel)
+                    ),
+                    pointwise_initializer=tf.keras.initializers.constant(
+                        np.sign(random_p_kernel)
+                    ),
                     input_shape=input_shape[1:],
                 )
             ]
@@ -151,7 +160,7 @@ class TestLayers:
                     kernel_size=3,
                     depthwise_quantizer="ste_sign",
                     input_quantizer="ste_sign",
-                    depthwise_initializer=const_init(random_weight),
+                    depthwise_initializer=tf.keras.initializers.constant(random_weight),
                 ),
                 input_data=input_data,
                 should_run_eagerly=keras_should_run_eagerly,
@@ -161,7 +170,9 @@ class TestLayers:
             [
                 tf.keras.layers.DepthwiseConv2D(
                     kernel_size=3,
-                    depthwise_initializer=const_init(np.sign(random_weight)),
+                    depthwise_initializer=tf.keras.initializers.constant(
+                        np.sign(random_weight)
+                    ),
                     input_shape=input_data.shape[1:],
                 )
             ]


### PR DESCRIPTION
This removes unnecessary computation from the layer tests which should result in a speed up.