### PR TITLE
Quantizer layer tests

### DIFF
--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -200,7 +200,6 @@ class TestLayerWarns:
         lq.layers.QuantSeparableConv2D(
             3, 3, depthwise_quantizer="ste_sign", pointwise_quantizer="ste_sign"
         )
-        assert len(caplog.records) == 2
         assert "depthwise_constraint" in caplog.text
         assert "pointwise_constraint" in caplog.text
 

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -58,14 +58,6 @@ PARAMS_SEP_LAYERS = [
 ]
 
 
-def random_input(shape):
-    for i, dim in enumerate(shape):
-        if dim is None:
-            shape[i] = np.random.randint(1, 4)
-    data = 10 * np.random.random(shape) - 0.5
-    return data.astype("float32")
-
-
 class TestLayers:
     @pytest.mark.parametrize(
         "quantized_layer, layer, input_shape, kwargs", PARAMS_ALL_LAYERS
@@ -73,7 +65,7 @@ class TestLayers:
     def test_binarization(
         self, quantized_layer, layer, input_shape, kwargs, keras_should_run_eagerly
     ):
-        input_data = random_input(input_shape)
+        input_data = testing_utils.random_input(input_shape)
         random_weight = np.random.random() - 0.5
 
         with lq.metrics.scope(["flip_ratio"]):
@@ -107,7 +99,7 @@ class TestLayers:
     def test_separable_layers(
         self, quantized_layer, layer, input_shape, keras_should_run_eagerly
     ):
-        input_data = random_input(input_shape)
+        input_data = testing_utils.random_input(input_shape)
         random_d_kernel = np.random.random() - 0.5
         random_p_kernel = np.random.random() - 0.5
 
@@ -150,7 +142,7 @@ class TestLayers:
         np.testing.assert_allclose(quant_output, fp_model.predict(np.sign(input_data)))
 
     def test_depthwise_layers(self, keras_should_run_eagerly):
-        input_data = random_input((2, 3, 7, 6))
+        input_data = testing_utils.random_input((2, 3, 7, 6))
         random_weight = np.random.random() - 0.5
 
         with lq.metrics.scope(["flip_ratio"]):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -61,12 +61,12 @@ class TestCommonFunctionality:
             lq.quantizers.get("unknown")
 
     @pytest.mark.parametrize("quantizer", ["input_quantizer", "kernel_quantizer"])
-    def test_layer_as_quantizer(self, quantizer):
+    def test_layer_as_quantizer(self, quantizer, keras_should_run_eagerly):
         input_data = testing_utils.random_input((1, 10))
         model = tf.keras.Sequential(
             [lq.layers.QuantDense(1, **{quantizer: DummyTrainableQuantizer()})]
         )
-        model.compile(optimizer="sgd", loss="mse")  # TODO modes?
+        model.compile(optimizer="sgd", loss="mse", run_eagerly=keras_should_run_eagerly)
         model.fit(input_data, np.ones((1,)), epochs=1)
 
 

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import pytest
 import larq as lq
-from larq.testing_utils import generate_real_values_with_zeros
+from larq import testing_utils
 
 
 class TestCommonFunctionality:
@@ -70,7 +70,7 @@ class TestQuantization:
         result = f([binarized_values])[0]
         np.testing.assert_allclose(result, binarized_values)
 
-        real_values = generate_real_values_with_zeros()
+        real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         assert not np.any(result == 0)
         assert np.all(result[real_values < 0] == -1)
@@ -89,7 +89,7 @@ class TestQuantization:
         result = f([binarized_values])[0]
         np.testing.assert_allclose(result, binarized_values)
 
-        real_values = generate_real_values_with_zeros()
+        real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         assert np.all(result[real_values <= 0] == 0)
         assert np.all(result[real_values > 0] == 1)
@@ -132,7 +132,7 @@ class TestQuantization:
         assert np.any(result == 1)
         assert np.any(result == 0)
 
-        real_values = generate_real_values_with_zeros()
+        real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         assert not np.any(result > 1)
         assert not np.any(result < -1)
@@ -146,7 +146,7 @@ class TestQuantization:
         test_threshold = 0.05  # This is the default
         f = tf.keras.backend.function([x], [lq.quantizers.get(fn)(x)])
 
-        real_values = generate_real_values_with_zeros()
+        real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         assert np.all(result[real_values > test_threshold] == 1)
         assert np.all(result[real_values < -test_threshold] == -1)
@@ -160,7 +160,7 @@ class TestQuantization:
         fn = lq.quantizers.SteTern(threshold_value=test_threshold)
         f = tf.keras.backend.function([x], [fn(x)])
 
-        real_values = generate_real_values_with_zeros()
+        real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         assert np.all(result[real_values > test_threshold] == 1)
         assert np.all(result[real_values < -test_threshold] == -1)
@@ -170,7 +170,7 @@ class TestQuantization:
 
     def test_ternarization_with_ternary_weight_networks(self):
         x = tf.keras.backend.placeholder(ndim=2)
-        real_values = generate_real_values_with_zeros()
+        real_values = testing_utils.generate_real_values_with_zeros()
         test_threshold = 0.7 * np.sum(np.abs(real_values)) / np.size(real_values)
         fn = lq.quantizers.SteTern(ternary_weight_networks=True)
         f = tf.keras.backend.function([x], [fn(x)])
@@ -188,7 +188,7 @@ class TestQuantization:
     def test_dorefa_quantize(self, fn):
         x = tf.keras.backend.placeholder(ndim=2)
         f = tf.keras.backend.function([x], [fn(x)])
-        real_values = generate_real_values_with_zeros()
+        real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         k_bit = 2
         n = 2 ** k_bit - 1
@@ -212,7 +212,7 @@ class TestGradients:
         [lq.quantizers.ste_sign, lq.quantizers.ste_tern, lq.quantizers.ste_heaviside],
     )
     def test_identity_ste_grad(self, eager_mode, fn):
-        x = generate_real_values_with_zeros(shape=(8, 3, 3, 16))
+        x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)
         with tf.GradientTape() as tape:
             activation = fn(tf_x, clip_value=None)
@@ -230,7 +230,7 @@ class TestGradients:
                 return 1.0
             return 0.0
 
-        x = generate_real_values_with_zeros(shape=(8, 3, 3, 16))
+        x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)
         with tf.GradientTape() as tape:
             activation = fn(tf_x)
@@ -244,7 +244,7 @@ class TestGradients:
                 beta * (2 - beta * x * np.tanh(beta * x / 2)) / (1 + np.cosh(beta * x))
             )
 
-        x = generate_real_values_with_zeros(shape=(8, 3, 3, 16))
+        x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)
         with tf.GradientTape() as tape:
             activation = lq.quantizers.swish_sign(tf_x)
@@ -263,7 +263,7 @@ class TestGradients:
                 return 2 - 2 * np.abs(x)
             return 0.0
 
-        x = generate_real_values_with_zeros(shape=(8, 3, 3, 16))
+        x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)
         with tf.GradientTape() as tape:
             activation = lq.quantizers.approx_sign(tf_x)
@@ -292,7 +292,7 @@ class TestGradients:
                 return 1.0
             return 0.0
 
-        x = generate_real_values_with_zeros(shape=(8, 3, 3, 16))
+        x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)
         with tf.GradientTape() as tape:
             activation = lq.quantizers.DoReFaQuantizer(2)(tf_x)

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -68,6 +68,14 @@ class TestCommonFunctionality:
         model.compile(optimizer="sgd", loss="mse")  # TODO modes?
         model.fit(input_data, np.ones((1,)), epochs=1)
 
+    def test_layer_as_kernel_quantizer(self):
+        input_data = testing_utils.random_input((1, 10))
+        model = tf.keras.Sequential(
+            [lq.layers.QuantDense(1, kernel_quantizer=DummyTrainableQuantizer())]
+        )
+        model.compile(optimizer="sgd", loss="mse")  # TODO modes?
+        model.fit(input_data, np.ones((1,)), epochs=1)
+
 
 class TestQuantization:
     """Test binarization and ternarization."""

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -62,12 +62,17 @@ class TestCommonFunctionality:
 
     @pytest.mark.parametrize("quantizer", ["input_quantizer", "kernel_quantizer"])
     def test_layer_as_quantizer(self, quantizer, keras_should_run_eagerly):
+        """Test whether a keras.layers.Layer can be used as quantizer."""
+
         input_data = testing_utils.random_input((1, 10))
+
         model = tf.keras.Sequential(
             [lq.layers.QuantDense(1, **{quantizer: DummyTrainableQuantizer()})]
         )
         model.compile(optimizer="sgd", loss="mse", run_eagerly=keras_should_run_eagerly)
         model.fit(input_data, np.ones((1,)), epochs=1)
+
+        assert any(["dummy_weight" in var.name for var in model.trainable_variables])
 
 
 class TestQuantization:

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -60,18 +60,11 @@ class TestCommonFunctionality:
         with pytest.raises(ValueError):
             lq.quantizers.get("unknown")
 
-    def test_layer_as_input_quantizer(self):
+    @pytest.mark.parametrize("quantizer", ["input_quantizer", "kernel_quantizer"])
+    def test_layer_as_quantizer(self, quantizer):
         input_data = testing_utils.random_input((1, 10))
         model = tf.keras.Sequential(
-            [lq.layers.QuantDense(1, input_quantizer=DummyTrainableQuantizer())]
-        )
-        model.compile(optimizer="sgd", loss="mse")  # TODO modes?
-        model.fit(input_data, np.ones((1,)), epochs=1)
-
-    def test_layer_as_kernel_quantizer(self):
-        input_data = testing_utils.random_input((1, 10))
-        model = tf.keras.Sequential(
-            [lq.layers.QuantDense(1, kernel_quantizer=DummyTrainableQuantizer())]
+            [lq.layers.QuantDense(1, **{quantizer: DummyTrainableQuantizer()})]
         )
         model.compile(optimizer="sgd", loss="mse")  # TODO modes?
         model.fit(input_data, np.ones((1,)), epochs=1)

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -35,6 +35,14 @@ def get_small_bnn_model(input_dim, num_hidden, output_dim, trainable_bn=True):
     return model
 
 
+def random_input(shape):
+    for i, dim in enumerate(shape):
+        if dim is None:
+            shape[i] = np.random.randint(1, 4)
+    data = 10 * np.random.random(shape) - 0.5
+    return data.astype("float32")
+
+
 # This is a fork of https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/testing_utils.py#L72
 # as recommended in https://github.com/tensorflow/tensorflow/issues/28601#issuecomment-492810252
 def layer_test(


### PR DESCRIPTION
This PR adds tests for using objects that inherit from `tf.keras.layers.Layer` as input or kernel quantizer. It also moves `random_input()` from `layers_test.py` to `testing_utils.py` so that `quantizer_test.py` can also use it.