### PR TITLE
Fix try except in model summary

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -83,7 +83,7 @@ def _format_table_entry(x, units=1):
         if type(x) == str or x == 0 or units == 1:
             return x
         return x / units
-    except:
+    except Exception:
         return "?"
 
 

--- a/larq/models.py
+++ b/larq/models.py
@@ -83,7 +83,7 @@ def _format_table_entry(x, units=1):
         if type(x) == str or x == 0 or units == 1:
             return x
         return x / units
-    except AssertionError:
+    except:
         return "?"
 
 


### PR DESCRIPTION
This was introduced in #328 and now makes model summary fail for some models since `x` in some cases can be `?` which makes `np.isnan` throw in a way that isn't caught by `AssertionError`.