### PR TITLE
Fix reloading of Bop when used with schedules

### DIFF
--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -270,6 +270,15 @@ class Bop(tf.keras.optimizers.Optimizer):
         }
         return {**super().get_config(), **config}
 
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        for hyper in ("gamma", "threshold"):
+            if hyper in config and isinstance(config[hyper], dict):
+                config[hyper] = tf.keras.optimizers.schedules.deserialize(
+                    config[hyper], custom_objects=custom_objects
+                )
+        return cls(**config)
+
     @staticmethod
     def is_binary_variable(var):
         """Returns True for binary variables named using the Larq Zoo naming scheme.

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -151,3 +151,14 @@ class TestBopOptimizer:
                 default_optimizer=tf.keras.optimizers.Adam(0.01),
             ),
         )
+
+    @pytest.mark.parametrize(
+        "hyper", [5e-4, tf.keras.optimizers.schedules.PolynomialDecay(5e-4, 100)],
+    )
+    def test_bop_serialization_schedule(self, hyper):
+        bop = lq.optimizers.Bop(gamma=hyper, threshold=hyper,)
+        new_bop = lq.optimizers.Bop.from_config(bop.get_config())
+        assert isinstance(new_bop._get_hyper("gamma"), type(bop._get_hyper("gamma")))
+        assert isinstance(
+            new_bop._get_hyper("threshold"), type(bop._get_hyper("threshold"))
+        )


### PR DESCRIPTION
This will fix deserialisation of Bop when used with learning rate schedules. The fix is following the way [TensorFlow handles optimizer reloading](https://github.com/tensorflow/tensorflow/blob/8ba91e00ca8ee525279094ba8b623b2b83489996/tensorflow/python/keras/optimizer_v2/optimizer_v2.py#L711-L733).