### PR TITLE
Fix reloading of case optimizer weights

### DIFF
--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -184,7 +184,7 @@ class TestLayerWarns:
         lq.layers.QuantDense(
             5, kernel_quantizer="ste_sign", kernel_constraint="weight_clip"
         )
-        assert caplog.records == []
+        assert "kernel_constraint" not in caplog.text
 
     def test_depthwise_layer_warns(self, caplog):
         lq.layers.QuantDepthwiseConv2D(5, depthwise_quantizer="ste_sign")
@@ -195,7 +195,7 @@ class TestLayerWarns:
         lq.layers.QuantDepthwiseConv2D(
             5, depthwise_quantizer="ste_sign", depthwise_constraint="weight_clip"
         )
-        assert caplog.records == []
+        assert "depthwise_constraint" not in caplog.text
 
     def test_separable_layer_warns(self, caplog):
         lq.layers.QuantSeparableConv2D(

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -98,6 +98,13 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             self.optimizers.append(self.default)
             self.DEFAULT_OPT_INDEX = len(self.pred_opt_pairs)
 
+    @property
+    def weights(self):
+        weights = []
+        for optimizer in self.optimizers:
+            weights.extend(optimizer.weights)
+        return weights
+
     def apply_gradients(self, grads_and_vars, name=None):
         """Apply gradients to variables for each optimizer.
 


### PR DESCRIPTION
We forgot to forward `optimizer.weights`. This PR fixes it to allow proper reloading of optimizer weights via `tf.keras.models.load_model` using `.h5` files.