### PR TITLE
Make HyperparameterScheduler compatible with CaseOptimizer

### DIFF
--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -29,10 +29,7 @@ class HyperparameterScheduler(tf.keras.callbacks.Callback):
 
     def __init__(self, schedule, hyperparameter, optimizer=None, verbose=0):
         super(HyperparameterScheduler, self).__init__()
-        if optimizer is None:
-            self.optimizer = self.model.optimizer
-        else:
-            self.optimizer = optimizer
+        self.optimizer = optimizer if optimizer else self.model.optimizer
         self.schedule = schedule
         self.hyperparameter = hyperparameter
         self.verbose = verbose

--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -27,9 +27,12 @@ class HyperparameterScheduler(tf.keras.callbacks.Callback):
     verbose: int. 0: quiet, 1: update messages.
     """
 
-    def __init__(self, optimizer, schedule, hyperparameter, verbose=0):
+    def __init__(self, schedule, hyperparameter,optimizer=None, verbose=0):
         super(HyperparameterScheduler, self).__init__()
-        self.optimizer = optimizer
+        if optimizer is None:
+            self.optimizer = self.model.optimizer
+        else:
+            self.optimizer = optimizer
         self.schedule = schedule
         self.hyperparameter = hyperparameter
         self.verbose = verbose

--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -13,7 +13,11 @@ class HyperparameterScheduler(tf.keras.callbacks.Callback):
             ),
             default_optimizer=tf.keras.optimizers.Adam(0.01),
         )
-        callbacks = [HyperparameterScheduler(lambda x:0.001*(0.1**(x//30)), 'gamma', optimizer.optimizers[0])]
+        callbacks = [
+            HyperparameterScheduler(
+                lambda x:0.001*(0.1**(x//30)), 'gamma', optimizer.optimizers[0]
+            )
+        ]
         ```
     # Arguments
     optimizer: the optimizer that contains the hyperparameter that will be scheduled.

--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -4,26 +4,39 @@ import tensorflow as tf
 class HyperparameterScheduler(tf.keras.callbacks.Callback):
     """Generic hyperparameter scheduler.
 
+    !!! example
+        ```python
+        optimizer = lq.optimizers.CaseOptimizer(
+            (
+                lq.optimizers.Bop.is_binary_variable,
+                lq.optimizers.Bop(threshold=1e-6, gamma=1e-3),
+            ),
+            default_optimizer=tf.keras.optimizers.Adam(0.01),
+        )
+        callbacks = [HyperparameterScheduler(lambda x:0.001*(0.1**(x//30)), 'gamma', optimizer.optimizers[0])]
+        ```
     # Arguments
+    optimizer: the optimizer that contains the hyperparameter that will be scheduled.
     schedule: a function that takes an epoch index as input
         (integer, indexed from 0) and returns a new hyperparameter as output.
     hyperparameter: str. the name of the hyperparameter to be scheduled.
     verbose: int. 0: quiet, 1: update messages.
     """
 
-    def __init__(self, schedule, hyperparameter, verbose=0):
+    def __init__(self, optimizer, schedule, hyperparameter, verbose=0):
         super(HyperparameterScheduler, self).__init__()
+        self.optimizer = optimizer
         self.schedule = schedule
         self.hyperparameter = hyperparameter
         self.verbose = verbose
 
     def on_epoch_begin(self, epoch, logs=None):
-        if not hasattr(self.model.optimizer, self.hyperparameter):
+        if not hasattr(self.optimizer, self.hyperparameter):
             raise ValueError(
                 f'Optimizer must have a "{self.hyperparameter}" attribute.'
             )
 
-        hp = getattr(self.model.optimizer, self.hyperparameter)
+        hp = getattr(self.optimizer, self.hyperparameter)
         try:  # new API
             hyperparameter_val = tf.keras.backend.get_value(hp)
             hyperparameter_val = self.schedule(epoch, hyperparameter_val)
@@ -34,10 +47,10 @@ class HyperparameterScheduler(tf.keras.callbacks.Callback):
 
         if self.verbose > 0:
             print(
-                f"Epoch {epoch + 1}: {self.hyperparameter} changning to {tf.keras.backend.get_value(hp)}."
+                f"Epoch {epoch + 1}: {self.hyperparameter} changing to {tf.keras.backend.get_value(hp)}."
             )
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        hp = getattr(self.model.optimizer, self.hyperparameter)
+        hp = getattr(self.optimizer, self.hyperparameter)
         logs[self.hyperparameter] = tf.keras.backend.get_value(hp)

--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -6,21 +6,18 @@ class HyperparameterScheduler(tf.keras.callbacks.Callback):
 
     !!! example
         ```python
+        bop = lq.optimizers.Bop(threshold=1e-6, gamma=1e-3)
+        adam = tf.keras.optimizers.Adam(0.01)
         optimizer = lq.optimizers.CaseOptimizer(
-            (
-                lq.optimizers.Bop.is_binary_variable,
-                lq.optimizers.Bop(threshold=1e-6, gamma=1e-3),
-            ),
-            default_optimizer=tf.keras.optimizers.Adam(0.01),
+            (lq.optimizers.Bop.is_binary_variable, bop), default_optimizer=adam,
         )
         callbacks = [
-            HyperparameterScheduler(
-                lambda x:0.001*(0.1**(x//30)), 'gamma', optimizer.optimizers[0]
-            )
+            HyperparameterScheduler(lambda x: 0.001 * (0.1 ** (x // 30)), "gamma", bop)
         ]
         ```
     # Arguments
     optimizer: the optimizer that contains the hyperparameter that will be scheduled.
+        Defaults to `self.model.optimizer` if `optimizer == None`.
     schedule: a function that takes an epoch index as input
         (integer, indexed from 0) and returns a new hyperparameter as output.
     hyperparameter: str. the name of the hyperparameter to be scheduled.

--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -27,7 +27,7 @@ class HyperparameterScheduler(tf.keras.callbacks.Callback):
     verbose: int. 0: quiet, 1: update messages.
     """
 
-    def __init__(self, schedule, hyperparameter,optimizer=None, verbose=0):
+    def __init__(self, schedule, hyperparameter, optimizer=None, verbose=0):
         super(HyperparameterScheduler, self).__init__()
         if optimizer is None:
             self.optimizer = self.model.optimizer

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -1,4 +1,12 @@
+import numpy as np
 import tensorflow as tf
+import larq as lq
+
+from larq import testing_utils as lq_testing_utils
+from larq.callbacks import HyperparameterScheduler
+
+from tensorflow import keras
+from tensorflow.python.keras import testing_utils
 
 
 class LogHistory(tf.keras.callbacks.Callback):
@@ -18,4 +26,76 @@ class LogHistory(tf.keras.callbacks.Callback):
 
 
 class TestHyperparameterScheduler:
-    pass
+    def test_hyper_parameter_scheduler(self):
+        np.random.seed(1337)
+        (x_train, y_train), (x_test, y_test) = testing_utils.get_test_data(
+            train_samples=1000, test_samples=0, input_shape=(10,), num_classes=2
+        )
+
+        y_train = keras.utils.to_categorical(y_train)
+
+        model = lq_testing_utils.get_small_bnn_model(
+            x_train.shape[1], 20, y_train.shape[1]
+        )
+        case_optimizer = lq.optimizers.CaseOptimizer(
+            (
+                lq.optimizers.Bop.is_binary_variable,
+                lq.optimizers.Bop(threshold=1e-6, gamma=1e-3),
+            ),
+            default_optimizer=tf.keras.optimizers.Adam(0.01),
+        )
+        model.compile(
+            loss="categorical_crossentropy",
+            optimizer=case_optimizer,
+            metrics=["accuracy"],
+        )
+
+        def scheduler(x):
+            return 1.0 / (1.0 + x)
+
+        cbk_gamma_scheduler = HyperparameterScheduler(
+            schedule=scheduler,
+            optimizer=model.optimizer.optimizers[0],
+            hyperparameter="gamma",
+            verbose=1,
+        )
+        cbk_threshold_scheduler = HyperparameterScheduler(
+            schedule=scheduler,
+            optimizer=model.optimizer.optimizers[0],
+            hyperparameter="threshold",
+            verbose=1,
+        )
+        cbk_lr_scheduler = HyperparameterScheduler(
+            schedule=scheduler,
+            optimizer=model.optimizer.optimizers[1],
+            hyperparameter="lr",
+            verbose=1,
+        )
+
+        num_epochs = 10
+        model.fit(
+            x_train,
+            y_train,
+            epochs=num_epochs,
+            batch_size=16,
+            callbacks=[cbk_gamma_scheduler, cbk_lr_scheduler, cbk_threshold_scheduler],
+            verbose=0,
+        )
+
+        np.testing.assert_almost_equal(
+            keras.backend.get_value(model.optimizer.optimizers[0].gamma),
+            scheduler(num_epochs - 1),
+            decimal=8,
+        )
+
+        np.testing.assert_almost_equal(
+            keras.backend.get_value(model.optimizer.optimizers[0].threshold),
+            scheduler(num_epochs - 1),
+            decimal=8,
+        )
+
+        np.testing.assert_almost_equal(
+            keras.backend.get_value(model.optimizer.optimizers[1].lr),
+            scheduler(num_epochs - 1),
+            decimal=8,
+        )

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -1,12 +1,10 @@
 import numpy as np
 import tensorflow as tf
-import larq as lq
+from tensorflow.python.keras import testing_utils
 
+import larq as lq
 from larq import testing_utils as lq_testing_utils
 from larq.callbacks import HyperparameterScheduler
-
-from tensorflow import keras
-from tensorflow.python.keras import testing_utils
 
 
 class LogHistory(tf.keras.callbacks.Callback):
@@ -32,7 +30,7 @@ class TestHyperparameterScheduler:
             train_samples=1000, test_samples=0, input_shape=(10,), num_classes=2
         )
 
-        y_train = keras.utils.to_categorical(y_train)
+        y_train = tf.keras.utils.to_categorical(y_train)
 
         model = lq_testing_utils.get_small_bnn_model(
             x_train.shape[1], 20, y_train.shape[1]
@@ -83,19 +81,19 @@ class TestHyperparameterScheduler:
         )
 
         np.testing.assert_almost_equal(
-            keras.backend.get_value(model.optimizer.optimizers[0].gamma),
+            tf.keras.backend.get_value(model.optimizer.optimizers[0].gamma),
             scheduler(num_epochs - 1),
             decimal=8,
         )
 
         np.testing.assert_almost_equal(
-            keras.backend.get_value(model.optimizer.optimizers[0].threshold),
+            tf.keras.backend.get_value(model.optimizer.optimizers[0].threshold),
             scheduler(num_epochs - 1),
             decimal=8,
         )
 
         np.testing.assert_almost_equal(
-            keras.backend.get_value(model.optimizer.optimizers[1].lr),
+            tf.keras.backend.get_value(model.optimizer.optimizers[1].lr),
             scheduler(num_epochs - 1),
             decimal=8,
         )

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -53,19 +53,19 @@ class TestHyperparameterScheduler:
 
         cbk_gamma_scheduler = HyperparameterScheduler(
             schedule=scheduler,
-            optimizer=bop,
+            optimizer=model.optimizer.optimizers[0],
             hyperparameter="gamma",
             verbose=1,
         )
         cbk_threshold_scheduler = HyperparameterScheduler(
             schedule=scheduler,
-            optimizer=bop,
+            optimizer=model.optimizer.optimizers[0],
             hyperparameter="threshold",
             verbose=1,
         )
         cbk_lr_scheduler = HyperparameterScheduler(
             schedule=scheduler,
-            optimizer=adam,
+            optimizer=model.optimizer.optimizers[1],
             hyperparameter="lr",
             verbose=1,
         )

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -53,19 +53,19 @@ class TestHyperparameterScheduler:
 
         cbk_gamma_scheduler = HyperparameterScheduler(
             schedule=scheduler,
-            optimizer=model.optimizer.optimizers[0],
+            optimizer=bop,
             hyperparameter="gamma",
             verbose=1,
         )
         cbk_threshold_scheduler = HyperparameterScheduler(
             schedule=scheduler,
-            optimizer=model.optimizer.optimizers[0],
+            optimizer=bop,
             hyperparameter="threshold",
             verbose=1,
         )
         cbk_lr_scheduler = HyperparameterScheduler(
             schedule=scheduler,
-            optimizer=model.optimizer.optimizers[1],
+            optimizer=adam,
             hyperparameter="lr",
             verbose=1,
         )

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -35,13 +35,13 @@ class TestHyperparameterScheduler:
         model = lq_testing_utils.get_small_bnn_model(
             x_train.shape[1], 20, y_train.shape[1]
         )
+
+        bop = lq.optimizers.Bop(threshold=1e-6, gamma=1e-3)
+        adam = tf.keras.optimizers.Adam(0.01)
         case_optimizer = lq.optimizers.CaseOptimizer(
-            (
-                lq.optimizers.Bop.is_binary_variable,
-                lq.optimizers.Bop(threshold=1e-6, gamma=1e-3),
-            ),
-            default_optimizer=tf.keras.optimizers.Adam(0.01),
+            (lq.optimizers.Bop.is_binary_variable, bop), default_optimizer=adam,
         )
+
         model.compile(
             loss="categorical_crossentropy",
             optimizer=case_optimizer,


### PR DESCRIPTION
This makes the HyperparameterScheduler compatible with the CaseOptimizer. The optimizer now needs to be passed as an argument as discussed in #347 

Fixes #347 