### PR TITLE
Simplify assign operations in Bop

### DIFF
--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -261,11 +261,9 @@ class Bop(tf.keras.optimizers.Optimizer):
         threshold = self._get_decayed_hyper("threshold", var_dtype)
         m = self.get_slot(var, "m")
 
-        m_t = tf.compat.v1.assign(
-            m, (1 - gamma) * m + gamma * grad, use_locking=self._use_locking
-        )
+        m_t = m.assign_add(gamma * (grad - m))
         var_t = lq.math.sign(-tf.sign(var * m_t - threshold) * var)
-        return tf.compat.v1.assign(var, var_t, use_locking=self._use_locking).op
+        return var.assign(var_t).op
 
     def _resource_apply_sparse(self, grad, var, indices):
         raise NotImplementedError()


### PR DESCRIPTION
The use of `tf.compat.v1.assign` was only to make sure we execute the same code path as TF. I am not sure if this is necessary for TF 1.x.

Let's see what CI thinks.