### PR TITLE
Use from_variable factory method to instantiate QuantizedVariables

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -3,7 +3,8 @@ import logging
 import tensorflow as tf
 
 from larq import metrics as lq_metrics
-from larq import quantized_scope, quantized_variable, quantizers
+from larq import quantized_scope, quantizers
+from larq.quantized_variable import QuantizedVariable
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class BaseLayer(tf.keras.layers.Layer):
         # Wrap `getter` with a version that returns a `QuantizedVariable`.
         def getter(*args, **kwargs):
             variable = old_getter(*args, **kwargs)
-            return quantized_variable.create_quantized_variable(variable, quantizer)
+            return QuantizedVariable.from_variable(variable, quantizer)
 
         return super()._add_variable_with_custom_getter(name, getter=getter, **kwargs)
 

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -2,8 +2,7 @@ import logging
 
 import tensorflow as tf
 
-from larq import metrics as lq_metrics
-from larq import quantized_scope, quantizers
+from larq import metrics as lq_metrics, quantized_scope, quantizers
 from larq.quantized_variable import QuantizedVariable
 
 log = logging.getLogger(__name__)

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -72,6 +72,30 @@ class QuantizedVariable(tf.Variable):
 
         return QuantizedDistributedVariable(variable, quantizer, precision)
 
+    @staticmethod
+    def _maybe_wrap(variable, quantizer, precision, wrap=True):
+        """Creates an QuantizedVariable that wraps another variable if applicable.
+
+        This function is used to wrap the return value of QuantizedVariable.assign.
+        Unfortunately MirroredVariable.assign will (incorrectly) return a Mirrored
+        value instead of a MirroredVariable. So we cannot properly wrap it in an
+        AutoCastVariable. We return the original variable in that case.
+
+        # Arguments
+        variable: A tf.Variable or op.
+        quantizer: An optional quantizer to transform the floating-point variable to a
+            fake quantized variable.
+        precision: An optional integer defining the precision of the quantized variable.
+            If `None`, `quantizer.precision` is used.
+        wrap: A boolean to define whether to wrap the variable in an QuantizedVariable.
+
+        # Returns
+        An QuantizedVariable if wrap is True and variable is a resource variable.
+        """
+        if wrap and resource_variable_ops.is_resource_variable(variable):
+            return QuantizedVariable.from_variable(variable, quantizer, precision)
+        return variable
+
     def _quantize(self, value):
         if self.quantizer and quantized_scope.should_quantize():
             return self.quantizer(value)
@@ -167,59 +191,59 @@ class QuantizedVariable(tf.Variable):
 
     def assign(self, value, use_locking=None, name=None, read_value=True):
         op = self.latent_variable.assign(value, use_locking, name, read_value)
-        return _maybe_wrap(op, self.quantizer, self.precision, wrap=read_value)
+        return self._maybe_wrap(op, self.quantizer, self.precision, wrap=read_value)
 
     def assign_add(self, delta, use_locking=None, name=None, read_value=True):
         op = self.latent_variable.assign_add(delta, use_locking, name, read_value)
-        return _maybe_wrap(op, self.quantizer, self.precision, wrap=read_value)
+        return self._maybe_wrap(op, self.quantizer, self.precision, wrap=read_value)
 
     def assign_sub(self, delta, use_locking=None, name=None, read_value=True):
         op = self.latent_variable.assign_sub(delta, use_locking, name, read_value)
-        return _maybe_wrap(op, self.quantizer, self.precision, wrap=read_value)
+        return self._maybe_wrap(op, self.quantizer, self.precision, wrap=read_value)
 
     def scatter_sub(self, *args, **kwargs):
         var = self.latent_variable.scatter_sub(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_add(self, *args, **kwargs):
         var = self.latent_variable.scatter_add(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_max(self, *args, **kwargs):
         var = self.latent_variable.scatter_max(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_min(self, *args, **kwargs):
         var = self.latent_variable.scatter_min(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_mul(self, *args, **kwargs):
         var = self.latent_variable.scatter_mul(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_div(self, *args, **kwargs):
         var = self.latent_variable.scatter_div(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_update(self, *args, **kwargs):
         var = self.latent_variable.scatter_update(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def batch_scatter_update(self, *args, **kwargs):
         var = self.latent_variable.batch_scatter_update(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_nd_sub(self, *args, **kwargs):
         var = self.latent_variable.scatter_nd_sub(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_nd_add(self, *args, **kwargs):
         var = self.latent_variable.scatter_nd_add(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def scatter_nd_update(self, *args, **kwargs):
         var = self.latent_variable.scatter_nd_update(*args, **kwargs)
-        return _maybe_wrap(var, self.quantizer, self.precision)
+        return self._maybe_wrap(var, self.quantizer, self.precision)
 
     def count_up_to(self, *args, **kwargs):
         return self.latent_variable.count_up_to(*args, **kwargs)
@@ -285,27 +309,3 @@ tf.register_tensor_conversion_function(
     QuantizedVariable, QuantizedVariable._dense_var_to_tensor
 )
 ops.register_dense_tensor_like_type(QuantizedVariable)
-
-
-def _maybe_wrap(variable, quantizer, precision, wrap=True):
-    """Creates an QuantizedVariable that wraps another variable if applicable.
-
-    This function is used to wrap the return value of QuantizedVariable.assign.
-    Unfortunately MirroredVariable.assign will (incorrectly) return a Mirrored
-    value instead of a MirroredVariable. So we cannot properly wrap it in an
-    AutoCastVariable. We return the original variable in that case.
-
-    # Arguments
-    variable: A tf.Variable or op.
-    quantizer: An optional quantizer to transform the floating-point variable to a
-        fake quantized variable.
-    precision: An optional integer defining the precision of the quantized variable.
-        If `None`, `quantizer.precision` is used.
-    wrap: A boolean to define whether to wrap the variable in an QuantizedVariable.
-
-    # Returns
-    An QuantizedVariable if wrap is True and variable is a resource variable.
-    """
-    if wrap and resource_variable_ops.is_resource_variable(variable):
-        return create_quantized_variable(variable, quantizer, precision)
-    return variable

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ line_length = 88
 use_parentheses = True
 multi_line_output = 3
 include_trailing_comma = True
+combine_as_imports = True
 skip =
     build
     dist


### PR DESCRIPTION
This allows creation of `QuantizedVariable` and `QuantizedDistributedVariable` using `QuantizedVariable.from_variable` following the naming conventions from `tf.data.Dataset.from_{tensors, tensor_slices, generator}`.

Closes #358 