### PR TITLE
Use integer as kernel_quantizer to mark layers that should use Bop

### DIFF
--- a/larq/layers.py
+++ b/larq/layers.py
@@ -69,7 +69,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -166,7 +166,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -276,7 +276,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -393,7 +393,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -503,7 +503,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
     input_quantizer: Quantization function applied to the input of the layer.
     depthwise_quantizer: Quantization function applied to the `depthwise_kernel`
         weights matrix or integer defining the desired precision if quantization should
-        be handled by an external optimizer.
+        be handled by an specialized optimizer.
     depthwise_initializer: Initializer for the depthwise kernel matrix.
     bias_initializer: Initializer for the bias vector.
     depthwise_regularizer: Regularizer function applied to the depthwise kernel matrix.
@@ -608,10 +608,10 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
     input_quantizer: Quantization function applied to the input of the layer.
     depthwise_quantizer: Quantization function applied to the depthwise kernel or
         nteger defining the desired precision if quantization should be handled by an
-        external optimizer.
+        specialized optimizer.
     pointwise_quantizer: Quantization function applied to the pointwise kernel or
         integer defining the desired precision if quantization should be handled by an
-        external optimizer.
+        specialized optimizer.
     depthwise_initializer: An initializer for the depthwise convolution kernel.
     pointwise_initializer: An initializer for the pointwise convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, the default
@@ -741,10 +741,10 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
     input_quantizer: Quantization function applied to the input of the layer.
     depthwise_quantizer: Quantization function applied to the depthwise kernel matrix
         or integer defining the desired precision if quantization should be handled by
-        an external optimizer.
+        an specialized optimizer.
     pointwise_quantizer: Quantization function applied to the pointwise kernel matrix
         or integer defining the desired precision if quantization should be handled by
-        an external optimizer.
+        an specialized optimizer.
     depthwise_initializer: Initializer for the depthwise kernel matrix.
     pointwise_initializer: Initializer for the pointwise kernel matrix.
     bias_initializer: Initializer for the bias vector.
@@ -879,7 +879,7 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -1008,7 +1008,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -1129,7 +1129,7 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -1267,7 +1267,7 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
     input_quantizer: Quantization function applied to the input of the layer.
     kernel_quantizer: Quantization function applied to the `kernel` weights matrix
         or integer defining the desired precision if quantization should be handled
-        by an external optimizer.
+        by an specialized optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -67,7 +67,9 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -162,7 +164,9 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
         is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -270,7 +274,9 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -385,7 +391,9 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -494,7 +502,8 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
     depthwise_quantizer: Quantization function applied to the `depthwise_kernel`
-        weights matrix.
+        weights matrix or integer defining the desired precision if quantization should
+        be handled by an external optimizer.
     depthwise_initializer: Initializer for the depthwise kernel matrix.
     bias_initializer: Initializer for the bias vector.
     depthwise_regularizer: Regularizer function applied to the depthwise kernel matrix.
@@ -597,8 +606,12 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
     activation: Activation function. Set it to None to maintain a linear activation.
     use_bias: Boolean, whether the layer uses a bias.
     input_quantizer: Quantization function applied to the input of the layer.
-    depthwise_quantizer: Quantization function applied to the depthwise kernel.
-    pointwise_quantizer: Quantization function applied to the pointwise kernel.
+    depthwise_quantizer: Quantization function applied to the depthwise kernel or
+        nteger defining the desired precision if quantization should be handled by an
+        external optimizer.
+    pointwise_quantizer: Quantization function applied to the pointwise kernel or
+        integer defining the desired precision if quantization should be handled by an
+        external optimizer.
     depthwise_initializer: An initializer for the depthwise convolution kernel.
     pointwise_initializer: An initializer for the pointwise convolution kernel.
     bias_initializer: An initializer for the bias vector. If None, the default
@@ -726,8 +739,12 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    depthwise_quantizer: Quantization function applied to the depthwise kernel matrix.
-    pointwise_quantizer: Quantization function applied to the pointwise kernel matrix.
+    depthwise_quantizer: Quantization function applied to the depthwise kernel matrix
+        or integer defining the desired precision if quantization should be handled by
+        an external optimizer.
+    pointwise_quantizer: Quantization function applied to the pointwise kernel matrix
+        or integer defining the desired precision if quantization should be handled by
+        an external optimizer.
     depthwise_initializer: Initializer for the depthwise kernel matrix.
     pointwise_initializer: Initializer for the pointwise kernel matrix.
     bias_initializer: Initializer for the bias vector.
@@ -860,7 +877,9 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -987,7 +1006,9 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -1106,7 +1127,9 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
@@ -1242,7 +1265,9 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
         no activation is applied (`a(x) = x`).
     use_bias: Boolean, whether the layer uses a bias vector.
     input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+    kernel_quantizer: Quantization function applied to the `kernel` weights matrix
+        or integer defining the desired precision if quantization should be handled
+        by an external optimizer.
     kernel_initializer: Initializer for the `kernel` weights matrix.
     bias_initializer: Initializer for the bias vector.
     kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -27,7 +27,9 @@ class BaseLayer(tf.keras.layers.Layer):
         # Wrap `getter` with a version that returns a `QuantizedVariable`.
         def getter(*args, **kwargs):
             variable = old_getter(*args, **kwargs)
-            return QuantizedVariable.from_variable(variable, quantizer)
+            if type(quantizer) == int:
+                return QuantizedVariable.from_variable(variable, precision=quantizer)
+            return QuantizedVariable.from_variable(variable, quantizer=quantizer)
 
         return super()._add_variable_with_custom_getter(name, getter=getter, **kwargs)
 

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -303,6 +303,7 @@ class Bop(tf.keras.optimizers.Optimizer):
         if precision == 1 and getattr(var, "quantizer", None) is not None:
             warnings.warn(
                 f"Calling Bop with `quantizer={var.quantizer}`; this might result in "
-                "unexpected behaviour or won't do anything."
+                "unexpected behaviour or won't do anything. "
+                "To assign a layer to Bop, set `kernel_quantizer=1`."
             )
         return precision == 1

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -206,9 +206,11 @@ class Bop(tf.keras.optimizers.Optimizer):
     Bop is a latent-free optimizer for Binarized Neural Networks (BNNs) and
     Binary Weight Networks (BWN).
 
-    To use Bop to train a model set `kernel_quantizer=1` for the layers where
-    binarization should be handled by Bop or use custom predicate function in the
-    `CaseOptimizer`.
+    To use Bop to train a model, set `kernel_quantizer=1` for the layers where training
+    and binarization should be handled by Bop. This is the easiest, recommended
+    approach. Alternatively, you can define a custom predicate function for the
+    `CaseOptimizer` that captures the set of layers you want to assign to Bop
+    (see Bop's `is_binary_var()` for example).
 
     Bop maintains an exponential moving average of the gradients controlled by
     `gamma`. If this average exceeds the `threshold`, a weight is flipped.

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -23,7 +23,11 @@ def _test_optimizer(
     y_train = keras.utils.to_categorical(y_train)
 
     model = lq_testing_utils.get_small_bnn_model(
-        x_train.shape[1], 20, y_train.shape[1], trainable_bn=trainable_bn
+        x_train.shape[1],
+        20,
+        y_train.shape[1],
+        kernel_quantizer=1,
+        trainable_bn=trainable_bn,
     )
     model.compile(loss="categorical_crossentropy", optimizer=optimizer, metrics=["acc"])
 
@@ -109,7 +113,12 @@ class TestCaseOptimizer:
         model = tf.keras.Sequential(
             [
                 tf.keras.layers.Flatten(input_shape=(28, 28)),
-                lq.layers.QuantDense(64, input_quantizer="ste_sign", activation="relu"),
+                lq.layers.QuantDense(
+                    64,
+                    input_quantizer="ste_sign",
+                    kernel_quantizer=1,
+                    activation="relu",
+                ),
                 tf.keras.layers.Dense(10, activation="softmax"),
             ]
         )

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -674,7 +674,7 @@ def get(identifier):
         return deserialize(identifier)
     if isinstance(identifier, str):
         return deserialize(str(identifier))
-    if callable(identifier):
+    if callable(identifier) or isinstance(identifier, int):
         return identifier
     raise ValueError(
         f"Could not interpret quantization function identifier: {identifier}"

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -56,7 +56,7 @@ class TestCommonFunctionality:
 
     def test_invalid_usage(self):
         with pytest.raises(ValueError):
-            lq.quantizers.get(42)
+            lq.quantizers.get(42.0)
         with pytest.raises(ValueError):
             lq.quantizers.get("unknown")
 

--- a/larq/testing_utils.py
+++ b/larq/testing_utils.py
@@ -33,12 +33,14 @@ def generate_real_values_with_zeros(low=-2, high=2, shape=(4, 10)):
     return real_values
 
 
-def get_small_bnn_model(input_dim, num_hidden, output_dim, trainable_bn=True):
+def get_small_bnn_model(
+    input_dim, num_hidden, output_dim, kernel_quantizer="ste_sign", trainable_bn=True
+):
     model = tf.keras.models.Sequential()
     model.add(
         lq.layers.QuantDense(
             units=num_hidden,
-            kernel_quantizer="ste_sign",
+            kernel_quantizer=kernel_quantizer,
             kernel_constraint="weight_clip",
             activation="relu",
             input_shape=(input_dim,),
@@ -49,7 +51,7 @@ def get_small_bnn_model(input_dim, num_hidden, output_dim, trainable_bn=True):
     model.add(
         lq.layers.QuantDense(
             units=output_dim,
-            kernel_quantizer="ste_sign",
+            kernel_quantizer=kernel_quantizer,
             kernel_constraint="weight_clip",
             input_quantizer="ste_sign",
             activation="softmax",


### PR DESCRIPTION
As discussed in https://github.com/larq/larq/issues/306#issuecomment-553978646, this allows to use integers as `kernel_quantizers` in layers to mark them to be used by external optimizers like Bop.

This will be a breaking change because previously `Bop` was applied to **all** quantized layers which made it impossible to use `larq` layers with different precisions in a network. Now `kernel_quantizers=1` needs to be set on all layers that should be optimized by `Bop`. `kernel_quantizers="ste_sign"` keeps working too, but will raise a warning message.

Please review carefully since this is a user level API change.
Do you think it would useful to add a `Bop.legacy_is_binary_variable` method that exposes the deprecated old behaviour to ease the migration?

Closes #306