### PR TITLE
Fix weight_clip documentation issue

### DIFF
--- a/docs/guides/bnn-architecture.md
+++ b/docs/guides/bnn-architecture.md
@@ -21,7 +21,7 @@ x_out = lq.layers.QuantDense(
     units=1024,
     input_quantizer=lq.quantizers.ste_sign,
     kernel_quantizer=lq.quantizers.ste_sign,
-    kernel_constraint=lq.constraints.weight_clip,
+    kernel_constraint=lq.constraints.WeightClip(clip_value=1.0),
     )(x_in)
 ```
 
@@ -80,7 +80,7 @@ def conv_with_shortcut(x):
         input_quantizer=lq.quantizers.ste_sign,
         kernel_quantizer=lq.quantizers.ste_sign,
         kernel_initializer="glorot_normal",
-        kernel_constraint=lq.constraints.weight_clip,
+        kernel_constraint=lq.constraints.WeightClip(clip_value=1.0),
         use_bias=False,
     )(x)
 
@@ -107,7 +107,7 @@ x = lq.layers.QuantConv2D(
     padding="same",
     input_quantizer=lq.quantizers.ste_sign,
     kernel_quantizer=lq.quantizers.ste_sign,
-    kernel_constraint=lq.constraints.weight_clip,
+    kernel_constraint=lq.constraints.WeightClip(clip_value=1.0),
     use_bias=False,
     )(x)
 x = tf.keras.layers.MaxPool2D(pool_size=3, strides=2)(x)


### PR DESCRIPTION
`lq.constraints.weight_clip` is an alias to `lq.constraints.WeightClip`, similar to how [upstream constraints](https://github.com/tensorflow/tensorflow/blob/5f8de9502dcf0bfb769a1df296b95b1241fc4d16/tensorflow/python/keras/constraints.py#L254-L258) are implemented. This means that `lq.constraints.weight_clip` is actually a `class` and therefor needs to be instantiated first (e.g. `lq.constraints.weight_clip()`).

This PR fixes our documentation to make it explicit. Closes #368 