### PR TITLE
Remove gast from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ tensorflow_datasets==1.3.2
 larq_zoo==0.5.0
 Pillow==7.0.0
 matplotlib==3.1.2
-gast==0.3.3  # See https://github.com/tensorflow/tensorflow/issues/32319


### PR DESCRIPTION
TensorFlow 2.1 now properly pins `gast==0.2.2`, so we don't need to explicitly include it here.

Closes #394