### PR TITLE
Fix optimizer reloading of CaseOptimizer with tf.train.Checkpoint

### DIFF
--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -104,6 +104,9 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             self.optimizers.append(self.default)
             self.DEFAULT_OPT_INDEX = len(self.pred_opt_pairs)
 
+        for i, optimizer in enumerate(self.optimizers):
+            self._track_trackable(optimizer, name=f"optimizer_{i}")
+
     @property
     def weights(self):
         weights = []

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -104,6 +104,7 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             self.optimizers.append(self.default)
             self.DEFAULT_OPT_INDEX = len(self.pred_opt_pairs)
 
+        # Track optimizers to support reloading via tf.train.Checkpoint
         for i, optimizer in enumerate(self.optimizers):
             self._track_trackable(optimizer, name=f"optimizer_{i}")
 

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -131,6 +131,30 @@ class TestCaseOptimizer:
                 checked_weights += 1
         assert checked_weights == len(opt_weights)
 
+    def test_checkpoint(self, eager_mode, tmp_path):
+        # Build and run a simple model.
+        var = tf.Variable([2.0])
+        opt = tf.keras.optimizers.SGD(1.0, momentum=1.0)
+        opt = lq.optimizers.CaseOptimizer((lambda var: True, opt))
+        run_fn = lambda: opt.minimize(lambda: var + 1.0, var_list=[var])
+        run_fn()
+        slot_var = opt.optimizers[0].get_slot(var, "momentum")
+        slot_value = slot_var.numpy().item()
+
+        # Save a checkpoint.
+        checkpoint = tf.train.Checkpoint(optimizer=opt, var=var)
+        save_path = checkpoint.save(tmp_path / "ckpt")
+
+        # Run model again.
+        run_fn()
+        assert slot_var.numpy().item() != slot_value
+
+        # Load checkpoint and ensure loss scale is back to it's original value.
+        status = checkpoint.restore(save_path)
+        status.assert_consumed()
+        status.run_restore_ops()
+        assert slot_var.numpy().item() == slot_value
+
 
 class TestBopOptimizer:
     def test_bop_accuracy(self):

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -148,7 +148,7 @@ class TestCaseOptimizer:
         opt.minimize(lambda: var + 1.0, var_list=[var])
         assert slot_var.numpy().item() != slot_value
 
-        # Load checkpoint and ensure loss scale is back to it's original value.
+        # Load checkpoint and ensure loss scale is back to its original value.
         status = checkpoint.restore(save_path)
         status.assert_consumed()
         status.run_restore_ops()

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -136,8 +136,7 @@ class TestCaseOptimizer:
         var = tf.Variable([2.0])
         opt = tf.keras.optimizers.SGD(1.0, momentum=1.0)
         opt = lq.optimizers.CaseOptimizer((lambda var: True, opt))
-        run_fn = lambda: opt.minimize(lambda: var + 1.0, var_list=[var])
-        run_fn()
+        opt.minimize(lambda: var + 1.0, var_list=[var])
         slot_var = opt.optimizers[0].get_slot(var, "momentum")
         slot_value = slot_var.numpy().item()
 
@@ -146,7 +145,7 @@ class TestCaseOptimizer:
         save_path = checkpoint.save(tmp_path / "ckpt")
 
         # Run model again.
-        run_fn()
+        opt.minimize(lambda: var + 1.0, var_list=[var])
         assert slot_var.numpy().item() != slot_value
 
         # Load checkpoint and ensure loss scale is back to it's original value.


### PR DESCRIPTION
Previously the the wrapped optimizers weren't tracked, so optimizer reloading didn't correctly work with `tf.train.Checkpoints`.