### PR TITLE
Lazily build metrics

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -76,9 +76,7 @@ class QuantizerBase(BaseLayer):
         super().build(input_shape)
         if self.kernel_quantizer:
             if "flip_ratio" in self._custom_metrics:
-                self.flip_ratio = lq_metrics.FlipRatio(
-                    values_shape=self.kernel.shape, name=f"flip_ratio/{self.name}"
-                )
+                self.flip_ratio = lq_metrics.FlipRatio(name=f"flip_ratio/{self.name}")
 
     def call(self, inputs):
         if self.input_quantizer:
@@ -132,10 +130,7 @@ class QuantizerDepthwiseBase(BaseLayer):
         super().build(input_shape)
         if self.depthwise_quantizer:
             if "flip_ratio" in self._custom_metrics:
-                self.flip_ratio = lq_metrics.FlipRatio(
-                    values_shape=self.depthwise_kernel.shape,
-                    name=f"flip_ratio/{self.name}",
-                )
+                self.flip_ratio = lq_metrics.FlipRatio(name=f"flip_ratio/{self.name}",)
 
     def call(self, inputs):
         if self.input_quantizer:
@@ -203,13 +198,11 @@ class QuantizerSeparableBase(BaseLayer):
         if self.depthwise_quantizer:
             if "flip_ratio" in self._custom_metrics:
                 self.depthwise_flip_ratio = lq_metrics.FlipRatio(
-                    values_shape=self.depthwise_kernel.shape,
                     name=f"flip_ratio/{self.name}_depthwise",
                 )
         if self.pointwise_quantizer:
             if "flip_ratio" in self._custom_metrics:
                 self.pointwise_flip_ratio = lq_metrics.FlipRatio(
-                    values_shape=self.pointwise_kernel.shape,
                     name=f"flip_ratio/{self.name}_pointwise",
                 )
 

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -91,11 +91,11 @@ class FlipRatio(tf.keras.metrics.Metric):
         self.built = False
         self.values_dtype = tf.as_dtype(values_dtype)
 
-    def __call__(self, inputs, *args, **kwargs):
+    def __call__(self, inputs, **kwargs):
         if not self.built:
             with tf.name_scope(self.name), tf.init_scope():
                 self.build(inputs.shape)
-        return super().__call__(inputs, *args, **kwargs)
+        return super().__call__(inputs, **kwargs)
 
     def build(self, input_shape):
         self._previous_values = self.add_weight(

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -86,32 +86,37 @@ class FlipRatio(tf.keras.metrics.Metric):
     dtype: Data type of the moving mean.
     """
 
-    def __init__(
-        self, values_shape=(), values_dtype="int8", name="flip_ratio", dtype=None
-    ):
+    def __init__(self, values_dtype="int8", name="flip_ratio", dtype=None):
         super().__init__(name=name, dtype=dtype)
+        self.built = False
         self.values_dtype = tf.as_dtype(values_dtype)
-        self.values_shape = tf.TensorShape(values_shape).as_list()
-        self.is_weight_metric = True
-        with tf.init_scope():
-            self._previous_values = self.add_weight(
-                "previous_values",
-                shape=values_shape,
-                dtype=self.values_dtype,
-                initializer=tf.keras.initializers.zeros,
-                aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
-            )
-            self.total = self.add_weight(
-                "total",
-                initializer=tf.keras.initializers.zeros,
-                aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
-            )
-            self.count = self.add_weight(
-                "count",
-                initializer=tf.keras.initializers.zeros,
-                aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
-            )
-        self._size = np.prod(self.values_shape)
+
+    def __call__(self, inputs, *args, **kwargs):
+        if not self.built:
+            with tf.name_scope(self.name), tf.init_scope():
+                self.build(inputs.shape)
+        return super().__call__(inputs, *args, **kwargs)
+
+    def build(self, input_shape):
+        self._previous_values = self.add_weight(
+            "previous_values",
+            shape=input_shape,
+            dtype=self.values_dtype,
+            initializer=tf.keras.initializers.zeros,
+            aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
+        )
+        self.total = self.add_weight(
+            "total",
+            initializer=tf.keras.initializers.zeros,
+            aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
+        )
+        self.count = self.add_weight(
+            "count",
+            initializer=tf.keras.initializers.zeros,
+            aggregation=tf.VariableAggregation.ONLY_FIRST_REPLICA,
+        )
+        self._size = tf.cast(np.prod(input_shape), self.dtype)
+        self.built = True
 
     def update_state(self, values, sample_weight=None):
         values = tf.cast(values, self.values_dtype)
@@ -133,8 +138,4 @@ class FlipRatio(tf.keras.metrics.Metric):
         )
 
     def get_config(self):
-        return {
-            **super().get_config(),
-            "values_shape": self.values_shape,
-            "values_dtype": self.values_dtype.name,
-        }
+        return {**super().get_config(), "values_dtype": self.values_dtype.name}

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -21,14 +21,12 @@ def test_config():
     assert mcv.stateful
     assert mcv.dtype == tf.float16
     assert mcv.values_dtype == tf.int16
-    # assert mcv.values_shape == [3, 3]
 
     mcv2 = metrics.FlipRatio.from_config(mcv.get_config())
     assert mcv2.name == "mcv"
     assert mcv2.stateful
     assert mcv2.dtype == tf.float16
     assert mcv2.values_dtype == tf.int16
-    # assert mcv2.values_shape == [3, 3]
 
 
 def test_metric(eager_mode):

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -31,20 +31,21 @@ def test_config():
 
 def test_metric(eager_mode):
     mcv = metrics.FlipRatio()
+    mcv.build((2,))
 
-    mcv(np.array([1, 1]))
+    mcv.update_state(np.array([1, 1]))
     assert all([1, 1] == mcv._previous_values.numpy())
     assert 0 == mcv.total.numpy()
     assert 1 == mcv.count.numpy()
     assert 0 == mcv.result().numpy()
 
-    mcv(np.array([2, 2]))
+    mcv.update_state(np.array([2, 2]))
     assert all([2, 2] == mcv._previous_values.numpy())
     assert 1 == mcv.total.numpy()
     assert 2 == mcv.count.numpy()
     assert 1 == mcv.result().numpy()
 
-    mcv(np.array([1, 2]))
+    mcv.update_state(np.array([1, 2]))
     assert all([1, 2] == mcv._previous_values.numpy())
     assert 1.5 == mcv.total.numpy()
     assert 3 == mcv.count.numpy()

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -32,6 +32,9 @@ def test_config():
 def test_metric(eager_mode):
     mcv = metrics.FlipRatio()
     mcv.build((2,))
+    assert 0 == mcv.result().numpy()
+    assert 0 == mcv.total.numpy()
+    assert 0 == mcv.count.numpy()
 
     mcv.update_state(np.array([1, 1]))
     assert all([1, 1] == mcv._previous_values.numpy())

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -57,9 +57,10 @@ def test_metric(eager_mode):
 
 def test_metric_in_graph_mode(graph_mode):
     mcv = metrics.FlipRatio()
+    mcv.build((2,))
 
     new_state = tf.compat.v1.placeholder(dtype=tf.float32, shape=[2])
-    update_state_op = mcv(new_state)
+    update_state_op = mcv.update_state(new_state)
     metric_value = mcv.result()
 
     with tf.compat.v1.Session() as sess:


### PR DESCRIPTION
This PR changes metrics to be built lazily on the first call of `update_state()` to pave the way for #402.