### PR TITLE
Add support for non-zero padding

### DIFF
--- a/larq/layers.py
+++ b/larq/layers.py
@@ -121,7 +121,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
 
 
 @utils.register_keras_custom_object
-class QuantConv1D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv1D):
+class QuantConv1D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv1D):
     """1D quantized convolution layer (e.g. temporal convolution).
 
     This layer creates a convolution kernel that is convolved with the layer input
@@ -223,7 +223,7 @@ class QuantConv1D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv1D):
 
 
 @utils.register_keras_custom_object
-class QuantConv2D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv2D):
+class QuantConv2D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv2D):
     """2D quantized convolution layer (e.g. spatial convolution over images).
 
     This layer creates a convolution kernel that is convolved
@@ -335,7 +335,7 @@ class QuantConv2D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv2D):
 
 
 @utils.register_keras_custom_object
-class QuantConv3D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv3D):
+class QuantConv3D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv3D):
     """3D convolution layer (e.g. spatial convolution over volumes).
 
     This layer creates a convolution kernel that is convolved
@@ -454,7 +454,7 @@ class QuantConv3D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv3D):
 
 @utils.register_keras_custom_object
 class QuantDepthwiseConv2D(
-    QuantizerBaseConv, QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv2D
+    QuantizerDepthwiseBase, QuantizerBaseConv, tf.keras.layers.DepthwiseConv2D
 ):
     """"Quantized depthwise separable 2D convolution.
     Depthwise Separable convolutions consists in performing just the first step in a
@@ -556,7 +556,7 @@ class QuantDepthwiseConv2D(
 
 @utils.register_keras_custom_object
 class QuantSeparableConv1D(
-    QuantizerBaseConv, QuantizerSeparableBase, tf.keras.layers.SeparableConv1D
+    QuantizerSeparableBase, QuantizerBaseConv, tf.keras.layers.SeparableConv1D
 ):
     """Depthwise separable 1D quantized convolution.
 
@@ -672,7 +672,7 @@ class QuantSeparableConv1D(
 
 @utils.register_keras_custom_object
 class QuantSeparableConv2D(
-    QuantizerBaseConv, QuantizerSeparableBase, tf.keras.layers.SeparableConv2D
+    QuantizerSeparableBase, QuantizerBaseConv, tf.keras.layers.SeparableConv2D
 ):
     """Depthwise separable 2D convolution.
 

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -11,6 +11,7 @@ import tensorflow as tf
 from larq import utils
 from larq.layers_base import (
     QuantizerBase,
+    QuantizerBaseConv,
     QuantizerDepthwiseBase,
     QuantizerSeparableBase,
 )
@@ -120,7 +121,7 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
 
 
 @utils.register_keras_custom_object
-class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
+class QuantConv1D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv1D):
     """1D quantized convolution layer (e.g. temporal convolution).
 
     This layer creates a convolution kernel that is convolved with the layer input
@@ -181,6 +182,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
         kernel_size,
         strides=1,
         padding="valid",
+        pad_values=0.0,
         data_format="channels_last",
         dilation_rate=1,
         activation=None,
@@ -201,6 +203,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
             kernel_size,
             strides=strides,
             padding=padding,
+            pad_values=pad_values,
             data_format=data_format,
             dilation_rate=dilation_rate,
             activation=activation,
@@ -219,7 +222,7 @@ class QuantConv1D(QuantizerBase, tf.keras.layers.Conv1D):
 
 
 @utils.register_keras_custom_object
-class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
+class QuantConv2D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv2D):
     """2D quantized convolution layer (e.g. spatial convolution over images).
 
     This layer creates a convolution kernel that is convolved
@@ -290,6 +293,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
         kernel_size,
         strides=(1, 1),
         padding="valid",
+        pad_values=0.0,
         data_format=None,
         dilation_rate=(1, 1),
         activation=None,
@@ -310,6 +314,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
             kernel_size,
             strides=strides,
             padding=padding,
+            pad_values=pad_values,
             data_format=data_format,
             dilation_rate=dilation_rate,
             activation=activation,
@@ -328,7 +333,7 @@ class QuantConv2D(QuantizerBase, tf.keras.layers.Conv2D):
 
 
 @utils.register_keras_custom_object
-class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
+class QuantConv3D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv3D):
     """3D convolution layer (e.g. spatial convolution over volumes).
 
     This layer creates a convolution kernel that is convolved
@@ -405,6 +410,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
         kernel_size,
         strides=(1, 1, 1),
         padding="valid",
+        pad_values=0.0,
         data_format=None,
         dilation_rate=(1, 1, 1),
         activation=None,
@@ -425,6 +431,7 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
             kernel_size,
             strides=strides,
             padding=padding,
+            pad_values=pad_values,
             data_format=data_format,
             dilation_rate=dilation_rate,
             activation=activation,
@@ -443,7 +450,9 @@ class QuantConv3D(QuantizerBase, tf.keras.layers.Conv3D):
 
 
 @utils.register_keras_custom_object
-class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv2D):
+class QuantDepthwiseConv2D(
+    QuantizerBaseConv, QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv2D
+):
     """"Quantized depthwise separable 2D convolution.
     Depthwise Separable convolutions consists in performing just the first step in a
     depthwise spatial convolution (which acts on each input channel separately).
@@ -503,6 +512,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
         kernel_size,
         strides=(1, 1),
         padding="valid",
+        pad_values=0.0,
         depth_multiplier=1,
         data_format=None,
         activation=None,
@@ -522,6 +532,7 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
             kernel_size=kernel_size,
             strides=strides,
             padding=padding,
+            pad_values=pad_values,
             depth_multiplier=depth_multiplier,
             data_format=data_format,
             activation=activation,
@@ -540,7 +551,9 @@ class QuantDepthwiseConv2D(QuantizerDepthwiseBase, tf.keras.layers.DepthwiseConv
 
 
 @utils.register_keras_custom_object
-class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv1D):
+class QuantSeparableConv1D(
+    QuantizerBaseConv, QuantizerSeparableBase, tf.keras.layers.SeparableConv1D
+):
     """Depthwise separable 1D quantized convolution.
 
     This layer performs a depthwise convolution that acts separately on channels,
@@ -603,6 +616,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         kernel_size,
         strides=1,
         padding="valid",
+        pad_values=0.0,
         data_format=None,
         dilation_rate=1,
         depth_multiplier=1,
@@ -628,6 +642,7 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
             kernel_size,
             strides=strides,
             padding=padding,
+            pad_values=pad_values,
             data_format=data_format,
             dilation_rate=dilation_rate,
             depth_multiplier=depth_multiplier,
@@ -651,7 +666,9 @@ class QuantSeparableConv1D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
 
 
 @utils.register_keras_custom_object
-class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv2D):
+class QuantSeparableConv2D(
+    QuantizerBaseConv, QuantizerSeparableBase, tf.keras.layers.SeparableConv2D
+):
     """Depthwise separable 2D convolution.
 
     Separable convolutions consist in first performing a depthwise spatial convolution
@@ -730,6 +747,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
         kernel_size,
         strides=(1, 1),
         padding="valid",
+        pad_values=0.0,
         data_format=None,
         dilation_rate=(1, 1),
         depth_multiplier=1,
@@ -755,6 +773,7 @@ class QuantSeparableConv2D(QuantizerSeparableBase, tf.keras.layers.SeparableConv
             kernel_size,
             strides=strides,
             padding=padding,
+            pad_values=pad_values,
             data_format=data_format,
             dilation_rate=dilation_rate,
             depth_multiplier=depth_multiplier,

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -150,6 +150,7 @@ class QuantConv1D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv1D):
         input[t+1:]. Useful when modeling temporal data where the model should not
         violate the temporal order. See [WaveNet: A Generative Model for Raw Audio,
             section 2.1](https://arxiv.org/abs/1609.03499).
+    pad_values: The pad value to use when `padding="same"`.
     data_format: A string, one of `channels_last` (default) or `channels_first`.
     dilation_rate: an integer or tuple/list of a single integer, specifying the dilation
         rate to use for dilated convolution. Currently, specifying any `dilation_rate`
@@ -249,6 +250,7 @@ class QuantConv2D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv2D):
         specify the same value for all spatial dimensions. Specifying any stride
         value != 1 is incompatible with specifying any `dilation_rate` value != 1.
     padding: one of `"valid"` or `"same"` (case-insensitive).
+    pad_values: The pad value to use when `padding="same"`.
     data_format: A string, one of `channels_last` (default) or `channels_first`.
         The ordering of the dimensions in the inputs. `channels_last` corresponds to
         inputs with shape `(batch, height, width, channels)` while `channels_first`
@@ -360,6 +362,7 @@ class QuantConv3D(QuantizerBaseConv, QuantizerBase, tf.keras.layers.Conv3D):
         same value for all spatial dimensions. Specifying any stride value != 1 is
         incompatible with specifying any `dilation_rate` value != 1.
     padding: one of `"valid"` or `"same"` (case-insensitive).
+    pad_values: The pad value to use when `padding="same"`.
     data_format: A string, one of `channels_last` (default) or `channels_first`.
         The ordering of the dimensions in the inputs. `channels_last` corresponds to
         inputs with shape `(batch, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
@@ -468,6 +471,7 @@ class QuantDepthwiseConv2D(
         same value for all spatial dimensions. Specifying any stride value != 1 is
         incompatible with specifying any `dilation_rate` value != 1.
     padding: one of `'valid'` or `'same'` (case-insensitive).
+    pad_values: The pad value to use when `padding="same"`.
     depth_multiplier: The number of depthwise convolution output channels for each input
         channel. The total number of depthwise convolution output channels will be equal
         to `filters_in * depth_multiplier`.
@@ -572,6 +576,7 @@ class QuantSeparableConv1D(
         Specifying any `stride` value != 1 is incompatible with specifying
         any `dilation_rate` value != 1.
     padding: One of `"valid"`, `"same"`, or `"causal"` (case-insensitive).
+    pad_values: The pad value to use when `padding="same"`.
     data_format: A string, one of `channels_last` (default) or `channels_first`.
         The ordering of the dimensions in the inputs. `channels_last` corresponds
         to inputs with shape `(batch, length, channels)` while `channels_first`
@@ -697,6 +702,7 @@ class QuantSeparableConv2D(
         the same value for all spatial dimensions. Specifying any stride value != 1
         is incompatible with specifying any `dilation_rate` value != 1.
     padding: one of `"valid"` or `"same"` (case-insensitive).
+    pad_values: The pad value to use when `padding="same"`.
     data_format: A string, one of `channels_last` (default) or `channels_first`.
         The ordering of the dimensions in the inputs. `channels_last` corresponds to
         inputs with shape `(batch, height, width, channels)` while `channels_first`

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -146,13 +146,13 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
 
     def call(self, inputs):
         if self._is_native_padding():
-            return super(QuantizerBaseConv, self).call(inputs)
+            return super().call(inputs)
 
         inputs = tf.pad(
             inputs, self._get_padding_same(inputs), constant_values=self.pad_values
         )
         with utils.patch_object(self, "padding", "valid"):
-            return super(QuantizerBaseConv, self).call(inputs)
+            return super().call(inputs)
 
     def get_config(self):
         return {

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -134,8 +134,8 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
             self._get_spatial_shape(input_shape)
         )
         if self.data_format == "channels_last":
-            return [input_shape[0], *spatial_shape, input_shape[-1]]
-        return [*input_shape[:2], *spatial_shape]
+            return tf.TensorShape([input_shape[0], *spatial_shape, input_shape[-1]])
+        return tf.TensorShape([*input_shape[:2], *spatial_shape])
 
     def build(self, input_shape):
         if self._is_native_padding():
@@ -146,13 +146,13 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
 
     def call(self, inputs):
         if self._is_native_padding():
-            return super().call(inputs)
+            return super(QuantizerBaseConv, self).call(inputs)
 
         inputs = tf.pad(
             inputs, self._get_padding_same(inputs), constant_values=self.pad_values
         )
         with utils.patch_object(self, "padding", "valid"):
-            return super().call(inputs)
+            return super(QuantizerBaseConv, self).call(inputs)
 
     def get_config(self):
         return {

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -190,6 +190,11 @@ class TestLayers:
         inputs = np.zeros(np.random.randint(5, 20, size=input_dim), np.float32)
         kernel = tuple(np.random.randint(3, 7, size=input_dim - 2))
         rand_tuple = tuple(np.random.randint(1, 4, size=input_dim - 2))
+        if not dilation and layer_cls in (
+            lq.layers.QuantSeparableConv2D,
+            lq.layers.QuantDepthwiseConv2D,
+        ):
+            rand_tuple = int(rand_tuple[0])
         kwargs = {"dilation_rate": rand_tuple} if dilation else {"strides": rand_tuple}
 
         args = (kernel,) if layer_cls == lq.layers.QuantDepthwiseConv2D else (2, kernel)

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -185,13 +185,16 @@ class TestLayers:
         ],
     )
     @pytest.mark.parametrize("data_format", ["channels_last", "channels_first"])
-    def test_non_zero_padding_layers(self, layer_cls, input_dim, data_format):
-        inputs = np.zeros(np.random.randint(2, 20, size=input_dim), np.float32)
-        kernel = tuple(np.random.randint(2, 7, size=input_dim - 2))
+    @pytest.mark.parametrize("dilation", [True, False])
+    def test_non_zero_padding_layers(self, layer_cls, input_dim, data_format, dilation):
+        inputs = np.zeros(np.random.randint(5, 20, size=input_dim), np.float32)
+        kernel = tuple(np.random.randint(3, 7, size=input_dim - 2))
+        rand_tuple = tuple(np.random.randint(1, 4, size=input_dim - 2))
+        kwargs = {"dilation_rate": rand_tuple} if dilation else {"strides": rand_tuple}
 
         args = (kernel,) if layer_cls == lq.layers.QuantDepthwiseConv2D else (2, kernel)
-        ref_layer = layer_cls(*args, padding="same")
-        layer = layer_cls(*args, padding="same", pad_values=1.0)
+        ref_layer = layer_cls(*args, padding="same", **kwargs)
+        layer = layer_cls(*args, padding="same", pad_values=1.0, **kwargs)
         assert layer(inputs).shape == ref_layer(inputs).shape
 
 

--- a/larq/utils.py
+++ b/larq/utils.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from tensorflow.keras.utils import get_custom_objects
 
 
@@ -57,3 +59,12 @@ def set_precision(precision: int = 32):
         return function
 
     return decorator
+
+
+@contextmanager
+def patch_object(object, name, value):
+    """Temporarily overwrite attribute on object"""
+    old_value = getattr(object, name)
+    setattr(object, name, value)
+    yield
+    setattr(object, name, old_value)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
             "pytest>=5.2.4,<5.4.0",
             "pytest-cov~=2.8.1",
             "pytest-xdist>=1.30,<1.32",
+            "pytest-mock~=2.0.0",
             "pytype>=2020.01.07,<2020.3.0",
             "snapshottest~=0.5.1",
         ],


### PR DESCRIPTION
This adds support for non zero padding for `QuantConv1D`, `QuantConv2D`, `QuantConv3D`, `QuantDepthwiseConv2D`, `QuantSeparableConv1D `and `QuantSeparableConv2D` in order to better support https://github.com/larq/compute-engine/pull/252

We can add support for locally connected layers and transposed convolutions in the future.