### PR TITLE
Move memory string formatting into utils

### DIFF
--- a/larq/__init__.py
+++ b/larq/__init__.py
@@ -7,6 +7,7 @@ import larq.metrics as metrics
 import larq.models as models
 import larq.optimizers as optimizers
 import larq.quantizers as quantizers
+import larq.utils as utils
 
 __all__ = [
     "layers",
@@ -18,4 +19,5 @@ __all__ = [
     "models",
     "quantizers",
     "optimizers",
+    "utils",
 ]

--- a/larq/models.py
+++ b/larq/models.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 from terminaltables import AsciiTable
 
 import larq.layers as lq_layers
+from larq.utils import memory_as_readable_str
 
 __all__ = ["summary"]
 
@@ -79,27 +80,6 @@ def _number_as_readable_str(num: float) -> str:
     num = f"{num:.3g}".rstrip(".")
     unit = ["", " k", " M", " B", " T"][magnitude]
     return num + unit
-
-
-def _memory_as_readable_str(num_bits: int) -> str:
-    """Generate a human-readable string for the memory size.
-
-    1 KiB = 1024 B; we use the binary prefix (KiB) [1,2] instead of the decimal prefix
-    (KB) to avoid any confusion with multiplying by 1000 instead of 1024.
-
-    [1] https://en.wikipedia.org/wiki/Binary_prefix
-    [2] https://physics.nist.gov/cuu/Units/binary.html
-    """
-
-    suffixes = ["B", "KiB", "MiB", "GiB"]
-    num_bytes = num_bits / 8
-
-    for i, suffix in enumerate(suffixes):
-        rounded = num_bytes / (1024 ** i)
-        if rounded < 1024:
-            break
-
-    return f"{rounded:,.2f} {suffix}"
 
 
 def _format_table_entry(x: float, units: int = 1) -> Union[float, str]:
@@ -356,8 +336,8 @@ class ModelProfile(LayerProfile):
                 "Non-trainable params",
                 _number_as_readable_str(self.weight_count(trainable=False)),
             ],
-            ["Model size:", _memory_as_readable_str(self.memory)],
-            ["Float-32 Equivalent", _memory_as_readable_str(self.fp_equivalent_memory)],
+            ["Model size:", memory_as_readable_str(self.memory)],
+            ["Float-32 Equivalent", memory_as_readable_str(self.fp_equivalent_memory)],
             [
                 "Compression Ratio of Memory",
                 self.memory / max(1e-8, self.fp_equivalent_memory),

--- a/larq/models.py
+++ b/larq/models.py
@@ -74,9 +74,9 @@ def _number_as_readable_str(num: float) -> str:
         magnitude += 1
         num /= 1000.0
 
-    # ':#.3g' formats the number with 3 significant figures, without stripping
-    # trailing zeros.
-    num = f"{num:#.3g}".rstrip(".")
+    # ':.3g' formats the number with 3 significant figures, without stripping trailing
+    # zeros.
+    num = f"{num:.3g}".rstrip(".")
     unit = ["", " k", " M", " B", " T"][magnitude]
     return num + unit
 

--- a/larq/models_test.py
+++ b/larq/models_test.py
@@ -128,58 +128,6 @@ def test_number_as_readable_str_large():
     assert lq.models._number_as_readable_str(1e16) == "1.00E+16"
 
 
-def test_memory_as_readable_str():
-    correct_strings = [  # 2^i bits, from i = 0 to 74
-        "0.12 B",
-        "0.25 B",
-        "0.50 B",
-        "1.00 B",
-        "2.00 B",
-        "4.00 B",
-        "8.00 B",
-        "16.00 B",
-        "32.00 B",
-        "64.00 B",
-        "128.00 B",
-        "256.00 B",
-        "512.00 B",
-        "1.00 KiB",
-        "2.00 KiB",
-        "4.00 KiB",
-        "8.00 KiB",
-        "16.00 KiB",
-        "32.00 KiB",
-        "64.00 KiB",
-        "128.00 KiB",
-        "256.00 KiB",
-        "512.00 KiB",
-        "1.00 MiB",
-        "2.00 MiB",
-        "4.00 MiB",
-        "8.00 MiB",
-        "16.00 MiB",
-        "32.00 MiB",
-        "64.00 MiB",
-        "128.00 MiB",
-        "256.00 MiB",
-        "512.00 MiB",
-        "1.00 GiB",
-        "2.00 GiB",
-        "4.00 GiB",
-        "8.00 GiB",
-        "16.00 GiB",
-        "32.00 GiB",
-        "64.00 GiB",
-        "128.00 GiB",
-        "256.00 GiB",
-        "512.00 GiB",
-        "1,024.00 GiB",
-    ]
-
-    for i, correct_string in enumerate(correct_strings):
-        assert lq.models._memory_as_readable_str(2 ** i) == correct_string
-
-
 @pytest.fixture(autouse=True)
 def run_around_tests():
     tf.keras.backend.clear_session()

--- a/larq/utils.py
+++ b/larq/utils.py
@@ -1,6 +1,27 @@
 from tensorflow.keras.utils import get_custom_objects
 
 
+def memory_as_readable_str(num_bits: int) -> str:
+    """Generate a human-readable string for the memory size.
+
+    1 KiB = 1024 B; we use the binary prefix (KiB) [1,2] instead of the decimal prefix
+    (KB) to avoid any confusion with multiplying by 1000 instead of 1024.
+
+    [1] https://en.wikipedia.org/wiki/Binary_prefix
+    [2] https://physics.nist.gov/cuu/Units/binary.html
+    """
+
+    suffixes = ["B", "KiB", "MiB", "GiB"]
+    num_bytes = num_bits / 8
+
+    for i, suffix in enumerate(suffixes):
+        rounded = num_bytes / (1024 ** i)
+        if rounded < 1024:
+            break
+
+    return f"{rounded:,.2f} {suffix}"
+
+
 def register_keras_custom_object(cls):
     """See https://github.com/tensorflow/addons/blob/master/tensorflow_addons/utils/keras_utils.py#L25"""
     get_custom_objects()[cls.__name__] = cls

--- a/larq/utils_test.py
+++ b/larq/utils_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 import larq as lq
 
 

--- a/larq/utils_test.py
+++ b/larq/utils_test.py
@@ -1,0 +1,55 @@
+import pytest
+
+import larq as lq
+
+
+def test_memory_as_readable_str():
+    correct_strings = [  # 2^i bits, from i = 0 to 74
+        "0.12 B",
+        "0.25 B",
+        "0.50 B",
+        "1.00 B",
+        "2.00 B",
+        "4.00 B",
+        "8.00 B",
+        "16.00 B",
+        "32.00 B",
+        "64.00 B",
+        "128.00 B",
+        "256.00 B",
+        "512.00 B",
+        "1.00 KiB",
+        "2.00 KiB",
+        "4.00 KiB",
+        "8.00 KiB",
+        "16.00 KiB",
+        "32.00 KiB",
+        "64.00 KiB",
+        "128.00 KiB",
+        "256.00 KiB",
+        "512.00 KiB",
+        "1.00 MiB",
+        "2.00 MiB",
+        "4.00 MiB",
+        "8.00 MiB",
+        "16.00 MiB",
+        "32.00 MiB",
+        "64.00 MiB",
+        "128.00 MiB",
+        "256.00 MiB",
+        "512.00 MiB",
+        "1.00 GiB",
+        "2.00 GiB",
+        "4.00 GiB",
+        "8.00 GiB",
+        "16.00 GiB",
+        "32.00 GiB",
+        "64.00 GiB",
+        "128.00 GiB",
+        "256.00 GiB",
+        "512.00 GiB",
+        "1,024.00 GiB",
+    ]
+
+    for i, correct_string in enumerate(correct_strings):
+        assert lq.utils.memory_as_readable_str(2 ** i) == correct_string


### PR DESCRIPTION
To prevent having to access a private method in other places where we (read: I) want to access `memory_as_readable_str()`, I've moved it into `larq/utils.py` and moved its test correspondingly.

This PR also removes that stray `#` that was confusing GitHub and Atom.