### PR TITLE
Model size for 8-bit quantized full-precision weights

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -112,7 +112,7 @@ class WeightProfile:
 
     @property
     def int8_fp_weights_memory(self) -> int:
-        """Count any 32- or 18-bit weights as 8 bits instead."""
+        """Count any 32- or 16-bit weights as 8 bits instead."""
 
         if self.bitwidth == 32 or self.bitwidth == 16:
             return self.count * 8

--- a/larq/models.py
+++ b/larq/models.py
@@ -352,11 +352,12 @@ class ModelProfile(LayerProfile):
                 "Non-trainable params",
                 _number_as_readable_str(self.weight_count(trainable=False)),
             ],
-            ["Model size:", memory_as_readable_str(self.memory)],
+            ["Model size", memory_as_readable_str(self.memory)],
             [
                 "Model size (8-bit FP weights)",
                 memory_as_readable_str(self.int8_fp_weights_memory),
-            ]["Float-32 Equivalent", memory_as_readable_str(self.fp_equivalent_memory)],
+            ],
+            ["Float-32 Equivalent", memory_as_readable_str(self.fp_equivalent_memory)],
             [
                 "Compression Ratio of Memory",
                 self.memory / max(1e-8, self.fp_equivalent_memory),

--- a/larq/models.py
+++ b/larq/models.py
@@ -114,7 +114,7 @@ class WeightProfile:
     def int8_fp_weights_memory(self) -> int:
         """Count any 32- or 16-bit weights as 8 bits instead."""
 
-        if self.bitwidth == 32 or self.bitwidth == 16:
+        if self.bitwidth > 8:
             return self.count * 8
         return self.bitwidth * self.count
 

--- a/larq/models_test.py
+++ b/larq/models_test.py
@@ -65,6 +65,14 @@ def test_layer_profile():
         0,
         32 * (32 * 11 * 11 * 10 + 10),
     ]
+    int8_fp_weights_mem = [
+        1 * (32 * 3 * 3 * 1) + 8 * 32,
+        0,
+        2 * (32 * 3 * 3),
+        1 * (32 * 3 * 3 * 1 + 32 * 1 * 1 * 32) + 8 * 32,
+        0,
+        8 * (32 * 11 * 11 * 10 + 10),
+    ]
     fp_equiv_mem = [32 * n for n in param_count]
     input_precision = [None, None, 2, 1, None, None]
     output_shape = [
@@ -95,6 +103,7 @@ def test_layer_profile():
         assert profiles[i].unique_op_precisions == unique_op_precisions[i]
         assert profiles[i].memory == memory[i]
         assert profiles[i].fp_equivalent_memory == fp_equiv_mem[i]
+        assert profiles[i].int8_fp_weights_memory == int8_fp_weights_mem[i]
         assert profiles[i].op_count("mac") == mac_count[i]
         assert profiles[i].op_count("mac", 1) == bin_mac_count[i]
 

--- a/larq/models_test.py
+++ b/larq/models_test.py
@@ -57,7 +57,7 @@ def test_layer_profile():
     ]
     bias_count = [32, 0, 0, 32, 0, 10]
     param_count = [k + b for k, b in zip(kernel_count, bias_count)]
-    memory = [
+    memory = [  # bits * (c * w * h * b) + bits * bias
         1 * (32 * 3 * 3 * 1) + 32 * 32,
         0,
         2 * (32 * 3 * 3),

--- a/larq/snapshots/snap_models_test.py
+++ b/larq/snapshots/snap_models_test.py
@@ -7,7 +7,9 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_summary 1'] = '''+sequential stats----------------------------------------------------------------------------------------------------------------+
+snapshots[
+    "test_summary 1"
+] = """+sequential stats----------------------------------------------------------------------------------------------------------------+
 | Layer                   Input prec.           Outputs  # 1-bit  # 2-bit  # 32-bit  Memory  1-bit MACs  2-bit MACs  32-bit MACs |
 |                               (bit)                        x 1      x 1       x 1    (kB)                                      |
 +--------------------------------------------------------------------------------------------------------------------------------+
@@ -32,9 +34,11 @@ snapshots['test_summary 1'] = '''+sequential stats------------------------------
 | Ratio of MACs that are binarized   0.1124     |
 | Ratio of MACs that are ternarized  0.0247     |
 +-----------------------------------------------+
-'''
+"""
 
-snapshots['test_summary 2'] = '''+sequential_1 stats--------------------+
+snapshots[
+    "test_summary 2"
+] = """+sequential_1 stats--------------------+
 | Layer   Input prec.  Outputs  Memory |
 |               (bit)             (kB) |
 +--------------------------------------+
@@ -52,4 +56,4 @@ snapshots['test_summary 2'] = '''+sequential_1 stats--------------------+
 | Compression Ratio of Memory    0.00   |
 | Number of MACs                 0      |
 +---------------------------------------+
-'''
+"""

--- a/larq/snapshots/snap_models_test.py
+++ b/larq/snapshots/snap_models_test.py
@@ -4,11 +4,10 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots[
-    "test_summary 1"
-] = """+sequential stats----------------------------------------------------------------------------------------------------------------+
+snapshots['test_summary 1'] = '''+sequential stats----------------------------------------------------------------------------------------------------------------+
 | Layer                   Input prec.           Outputs  # 1-bit  # 2-bit  # 32-bit  Memory  1-bit MACs  2-bit MACs  32-bit MACs |
 |                               (bit)                        x 1      x 1       x 1    (kB)                                      |
 +--------------------------------------------------------------------------------------------------------------------------------+
@@ -25,18 +24,17 @@ snapshots[
 | Total params                       40.7 k     |
 | Trainable params                   1.95 k     |
 | Non-trainable params               38.7 k     |
-| Model size:                        151.80 KiB |
+| Model size                         151.80 KiB |
+| Model size (8-bit FP weights)      38.15 KiB  |
 | Float-32 Equivalent                158.91 KiB |
 | Compression Ratio of Memory        0.96       |
 | Number of MACs                     1.41 M     |
 | Ratio of MACs that are binarized   0.1124     |
 | Ratio of MACs that are ternarized  0.0247     |
 +-----------------------------------------------+
-"""
+'''
 
-snapshots[
-    "test_summary 2"
-] = """+sequential_1 stats--------------------+
+snapshots['test_summary 2'] = '''+sequential_1 stats--------------------+
 | Layer   Input prec.  Outputs  Memory |
 |               (bit)             (kB) |
 +--------------------------------------+
@@ -44,13 +42,14 @@ snapshots[
 +--------------------------------------+
 | Total                              0 |
 +--------------------------------------+
-+sequential_1 summary-----------------+
-| Total params                 0      |
-| Trainable params             0      |
-| Non-trainable params         0      |
-| Model size:                  0.00 B |
-| Float-32 Equivalent          0.00 B |
-| Compression Ratio of Memory  0.00   |
-| Number of MACs               0      |
-+-------------------------------------+
-"""
++sequential_1 summary-------------------+
+| Total params                   0      |
+| Trainable params               0      |
+| Non-trainable params           0      |
+| Model size                     0.00 B |
+| Model size (8-bit FP weights)  0.00 B |
+| Float-32 Equivalent            0.00 B |
+| Compression Ratio of Memory    0.00   |
+| Number of MACs                 0      |
++---------------------------------------+
+'''


### PR DESCRIPTION
This PR implements a new model summary property: model size if full-precision weights are quantized to be `int8` instead of `float32`; e.g. if they take up 1 byte of space instead of 4.

I'm also doing this for 16-bit weights in case the model is trained using half precision, but I'm not sure if this is necessary--the weights could still be stored as 32 bits by TensorFlow. If that's the case I'm happy to remove the second case in the if statement in the `int8_fp_weights_memory` property.

Closes #448.