### PR TITLE
Add quantized variable fixes from TF upstream

### DIFF
--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -3,7 +3,10 @@
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.python.distribute.values import AggregatingVariable, DistributedVariable  # type: ignore
+from tensorflow.python.distribute.values import (  # type: ignore
+    AggregatingVariable,
+    DistributedVariable,
+)
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import resource_variable_ops
 

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.python.distribute.values import DistributedVariable
+from tensorflow.python.distribute.values import AggregatingVariable, DistributedVariable
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import resource_variable_ops
 
@@ -74,11 +74,15 @@ class QuantizedVariable(tf.Variable):
         # Returns
         A QuantizedVariable that wraps the variable.
         """
-        if not isinstance(variable, DistributedVariable):  # type: ignore
+        if not isinstance(variable, (DistributedVariable, AggregatingVariable)):
             return cls(variable, quantizer, precision)
 
         class QuantizedDistributedVariable(cls, variable.__class__):
-            """A QuantizedVariable that also subclasses from DistributedVariable."""
+            """A QuantizedVariable that also subclasses from `variable.__class__`.
+
+            `variable.__class__` is either a `DistributedVariable` or an
+            `AggregatingVariable`.
+            """
 
             def get(self, *args, **kwargs):
                 # For some reason this is needed to make unit `x + x` pass on TF 1.14

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -184,7 +184,7 @@ class QuantizedVariable(tf.Variable):
     #
     # We do not define the following methods from Variable for the following
     # reasons:
-    #   * 'experimental_ref': Instead we inherit the definition from Variable.
+    #   * 'ref': Instead we inherit the definition from Variable.
     #     If we defined and delegated to Variable, the ref of an QuantizedVariable
     #     would be the same as the ref of the underlying variable, which would be
     #     strange as they are different Python objects.

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.python.distribute.values import AggregatingVariable, DistributedVariable
+from tensorflow.python.distribute.values import AggregatingVariable, DistributedVariable  # type: ignore
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import resource_variable_ops
 
@@ -74,7 +74,7 @@ class QuantizedVariable(tf.Variable):
         # Returns
         A QuantizedVariable that wraps the variable.
         """
-        if not isinstance(variable, (DistributedVariable, AggregatingVariable)):
+        if not isinstance(variable, (DistributedVariable, AggregatingVariable)):  # type: ignore
             return cls(variable, quantizer, precision)
 
         class QuantizedDistributedVariable(cls, variable.__class__):


### PR DESCRIPTION
This brings in changes from the following commits to improve compatibility of quantized variables:
- https://github.com/tensorflow/tensorflow/commit/9c7c7c9979d66e97aeb8717d87f351df5ecbf56b#diff-8db8dd75efb914430be51c632dfa452e
- https://github.com/tensorflow/tensorflow/commit/d4dacbcb2a9a58acaee6c7c30966281cb7f35073#diff-8db8dd75efb914430be51c632dfa452e
- https://github.com/tensorflow/tensorflow/commit/1fcda57f37c2ac854cabf1c3462eb14e39d36c60
