### PR TITLE
Batchnorm in profile

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -158,18 +158,15 @@ class LayerProfile:
 
     @property
     def memory(self) -> int:
-        mem = sum(p.memory for p in self.weight_profiles)
-        return mem
+        return sum(p.memory for p in self.weight_profiles)
 
     @property
     def int8_fp_weights_memory(self) -> int:
-        mem = sum(p.int8_fp_weights_memory for p in self.weight_profiles)
-        return mem
+        return sum(p.int8_fp_weights_memory for p in self.weight_profiles)
 
     @property
     def fp_equivalent_memory(self) -> int:
-        mem = sum(p.fp_equivalent_memory for p in self.weight_profiles)
-        return mem
+        return sum(p.fp_equivalent_memory for p in self.weight_profiles)
 
     def weight_count(
         self, bitwidth: Optional[int] = None, trainable: Optional[bool] = None

--- a/larq/models.py
+++ b/larq/models.py
@@ -2,11 +2,12 @@ import itertools
 from dataclasses import dataclass
 from typing import Any, Callable, Iterator, Mapping, Optional, Sequence, TypeVar, Union
 
-import larq.layers as lq_layers
 import numpy as np
 import tensorflow as tf
-from larq.utils import memory_as_readable_str
 from terminaltables import AsciiTable
+
+import larq.layers as lq_layers
+from larq.utils import memory_as_readable_str
 
 __all__ = ["summary"]
 

--- a/larq/models_test.py
+++ b/larq/models_test.py
@@ -1,8 +1,9 @@
 import larq as lq
 import numpy as np
-import pytest
 import tensorflow as tf
 from larq.models import ModelProfile
+
+import pytest
 
 
 def get_profile_model():
@@ -24,7 +25,7 @@ def get_profile_model():
                 padding="same",
                 use_bias=False,
             ),
-            tf.keras.layers.BatchNormalization(),
+            tf.keras.layers.BatchNormalization(scale=False),
             lq.layers.QuantSeparableConv2D(
                 32,
                 (3, 3),

--- a/larq/models_test.py
+++ b/larq/models_test.py
@@ -1,9 +1,9 @@
-import larq as lq
 import numpy as np
-import tensorflow as tf
-from larq.models import ModelProfile
-
 import pytest
+import tensorflow as tf
+
+import larq as lq
+from larq.models import ModelProfile
 
 
 def get_profile_model():

--- a/larq/models_test.py
+++ b/larq/models_test.py
@@ -1,8 +1,7 @@
+import larq as lq
 import numpy as np
 import pytest
 import tensorflow as tf
-
-import larq as lq
 from larq.models import ModelProfile
 
 
@@ -25,6 +24,7 @@ def get_profile_model():
                 padding="same",
                 use_bias=False,
             ),
+            tf.keras.layers.BatchNormalization(),
             lq.layers.QuantSeparableConv2D(
                 32,
                 (3, 3),
@@ -41,7 +41,7 @@ def get_profile_model():
 
 def test_model_profile():
     profile = ModelProfile(get_profile_model())
-    assert len(profile.layer_profiles) == 6
+    assert len(profile.layer_profiles) == 7
 
 
 def test_layer_profile():
@@ -51,16 +51,18 @@ def test_layer_profile():
         32 * 3 * 3 * 1,
         0,
         32 * 3 * 3,
+        0,
         32 * 3 * 3 * 1 + 32 * 1 * 1 * 32,
         0,
         32 * 11 * 11 * 10,
     ]
-    bias_count = [32, 0, 0, 32, 0, 10]
+    bias_count = [32, 0, 0, 64, 32, 0, 10]
     param_count = [k + b for k, b in zip(kernel_count, bias_count)]
     memory = [  # bits * (c * w * h * b) + bits * bias
         1 * (32 * 3 * 3 * 1) + 32 * 32,
         0,
         2 * (32 * 3 * 3),
+        32 * (2 * 32),
         1 * (32 * 3 * 3 * 1 + 32 * 1 * 1 * 32) + 32 * 32,
         0,
         32 * (32 * 11 * 11 * 10 + 10),
@@ -69,23 +71,25 @@ def test_layer_profile():
         1 * (32 * 3 * 3 * 1) + 8 * 32,
         0,
         2 * (32 * 3 * 3),
+        8 * (32 * 2),
         1 * (32 * 3 * 3 * 1 + 32 * 1 * 1 * 32) + 8 * 32,
         0,
         8 * (32 * 11 * 11 * 10 + 10),
     ]
     fp_equiv_mem = [32 * n for n in param_count]
-    input_precision = [None, None, 2, 1, None, None]
+    input_precision = [None, None, 2, None, 1, None, None]
     output_shape = [
         (-1, 64, 64, 32),
         (-1, 32, 32, 32),
+        (-1, 11, 11, 32),
         (-1, 11, 11, 32),
         (-1, 11, 11, 32),
         (-1, 11 * 11 * 32),
         (-1, 10),
     ]
     output_pixels = [int(np.prod(os[1:-1])) for os in output_shape]
-    unique_param_bidtwidths = [[1, 32], [], [2], [1, 32], [], [32]]
-    unique_op_precisions = [[32], [], [2], [1], [], [32]]
+    unique_param_bidtwidths = [[1, 32], [], [2], [32], [1, 32], [], [32]]
+    unique_op_precisions = [[32], [], [2], [], [1], [], [32]]
     mac_count = [params * pixels for params, pixels in zip(kernel_count, output_pixels)]
     bin_mac_count = [
         mc if (1 in pb and ip == 1) else 0

--- a/larq/snapshots/snap_models_test.py
+++ b/larq/snapshots/snap_models_test.py
@@ -23,7 +23,7 @@ snapshots['test_summary 1'] = '''+sequential stats------------------------------
 +--------------------------------------------------------------------------------------------------------------------------------+
 +sequential summary-----------------------------+
 | Total params                       40.7 k     |
-| Trainable params                   1.98 k     |
+| Trainable params                   1.95 k     |
 | Non-trainable params               38.8 k     |
 | Model size                         152.05 KiB |
 | Model size (8-bit FP weights)      38.21 KiB  |

--- a/larq/snapshots/snap_models_test.py
+++ b/larq/snapshots/snap_models_test.py
@@ -7,38 +7,35 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots[
-    "test_summary 1"
-] = """+sequential stats----------------------------------------------------------------------------------------------------------------+
+snapshots['test_summary 1'] = '''+sequential stats----------------------------------------------------------------------------------------------------------------+
 | Layer                   Input prec.           Outputs  # 1-bit  # 2-bit  # 32-bit  Memory  1-bit MACs  2-bit MACs  32-bit MACs |
 |                               (bit)                        x 1      x 1       x 1    (kB)                                      |
 +--------------------------------------------------------------------------------------------------------------------------------+
 | quant_conv2d                      -  (-1, 64, 64, 32)      288        0        32    0.16           0           0      1179648 |
 | max_pooling2d                     -  (-1, 32, 32, 32)        0        0         0       0           0           0            0 |
 | quant_depthwise_conv2d            2  (-1, 11, 11, 32)        0      288         0    0.07           0       34848            0 |
+| batch_normalization               -  (-1, 11, 11, 32)        0        0        64    0.25           0           0            0 |
 | quant_separable_conv2d            1  (-1, 11, 11, 32)     1312        0        32    0.29      158752           0            0 |
 | flatten                           -        (-1, 3872)        0        0         0       0           0           0            0 |
 | dense                             -          (-1, 10)        0        0     38730  151.29           0           0        38720 |
 +--------------------------------------------------------------------------------------------------------------------------------+
-| Total                                                     1600      288     38794  151.80      158752       34848      1218368 |
+| Total                                                     1600      288     38858  152.05      158752       34848      1218368 |
 +--------------------------------------------------------------------------------------------------------------------------------+
 +sequential summary-----------------------------+
 | Total params                       40.7 k     |
-| Trainable params                   1.95 k     |
-| Non-trainable params               38.7 k     |
-| Model size                         151.80 KiB |
-| Model size (8-bit FP weights)      38.15 KiB  |
-| Float-32 Equivalent                158.91 KiB |
+| Trainable params                   1.98 k     |
+| Non-trainable params               38.8 k     |
+| Model size                         152.05 KiB |
+| Model size (8-bit FP weights)      38.21 KiB  |
+| Float-32 Equivalent                159.16 KiB |
 | Compression Ratio of Memory        0.96       |
 | Number of MACs                     1.41 M     |
 | Ratio of MACs that are binarized   0.1124     |
 | Ratio of MACs that are ternarized  0.0247     |
 +-----------------------------------------------+
-"""
+'''
 
-snapshots[
-    "test_summary 2"
-] = """+sequential_1 stats--------------------+
+snapshots['test_summary 2'] = '''+sequential_1 stats--------------------+
 | Layer   Input prec.  Outputs  Memory |
 |               (bit)             (kB) |
 +--------------------------------------+
@@ -56,4 +53,4 @@ snapshots[
 | Compression Ratio of Memory    0.00   |
 | Number of MACs                 0      |
 +---------------------------------------+
-"""
+'''


### PR DESCRIPTION
Currently, the profile simply counts BN weights, usually resulting in 4 full-precision variables per batch norm channel. However, for inference these are fused into 2. As these variables are full-precision, this can have a noticeable impact on total model size, especially in deep networks with lots of batch norms. This PR fixes this by only profiling relevant weights in the BN layer.

(This is a bit of a slippery slope, we can't anticipate all conversion-time optimizations in the profile. However, given that this particular optimization is both very common and easy to accommodate for, it's worth fixing.)