### PR TITLE
Fix deserialization of quantizer functions

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -606,6 +606,6 @@ def get_kernel_quantizer(identifier):
     `Quantizer` or `None`
     """
     quantizer = get(identifier)
-    if quantizer and not quantizer._custom_metrics:
-        quantizer._custom_metrics = context.get_training_metrics()
+    if isinstance(quantizer, BaseQuantizer) and not quantizer._custom_metrics:
+        quantizer._custom_metrics = list(context.get_training_metrics())
     return quantizer

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -391,3 +391,18 @@ def test_metrics(quantizer):
         # In TF1.14, call() gets called twice, resulting in having an extra initial
         # metrics copy.
         assert len(model.layers[0].kernel_quantizer._metrics) == 2
+
+
+def test_get_kernel_quantizer_assigns_metrics():
+    with lq.context.metrics_scope(["flip_ratio"]):
+        ste_sign = lq.quantizers.get_kernel_quantizer("ste_sign")
+        assert "flip_ratio" in lq.context.get_training_metrics()
+
+    assert isinstance(ste_sign, lq.quantizers.SteSign)
+    assert "flip_ratio" in ste_sign._custom_metrics
+
+
+def test_get_kernel_quantizer_accepts_function():
+    custom_quantizer = lq.quantizers.get_kernel_quantizer(lambda x: x)
+    assert callable(custom_quantizer)
+    assert not hasattr(custom_quantizer, "_custom_metrics")


### PR DESCRIPTION
This should fix CI failures in https://github.com/larq/zoo/pull/130/checks?check_run_id=501436869 and makes sure that `quantizer._custom_metrics` are always a `list`.