### PR TITLE
Support unknown input shapes with one padding

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -14,7 +14,7 @@ def _compute_padding(stride, dilation_rate, input_size, filter_size):
     effective_filter_size = (filter_size - 1) * dilation_rate + 1
     output_size = (input_size + stride - 1) // stride
     total_padding = (output_size - 1) * stride + effective_filter_size - input_size
-    total_padding = total_padding if total_padding > 0 else 0
+    total_padding = max(total_padding, 0)
     padding = total_padding // 2
     return padding, padding + (total_padding % 2)
 
@@ -108,12 +108,6 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
             )
         )
 
-    def _get_spatial_padding_same_shape(self, shape):
-        return [
-            size + sum(pad)
-            for size, pad in zip(shape, self._get_spatial_padding_same(shape))
-        ]
-
     def _get_spatial_shape(self, input_shape):
         return (
             input_shape[1:-1]
@@ -130,9 +124,10 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
         )
 
     def _get_padding_same_shape(self, input_shape):
-        spatial_shape = self._get_spatial_padding_same_shape(
-            self._get_spatial_shape(input_shape)
-        )
+        spatial_shape = [
+            (size + stride - 1) // stride if size is not None else None
+            for size, stride in zip(self._get_spatial_shape(input_shape), self.strides)
+        ]
         if self.data_format == "channels_last":
             return tf.TensorShape([input_shape[0], *spatial_shape, input_shape[-1]])
         return tf.TensorShape([*input_shape[:2], *spatial_shape])

--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -101,12 +101,12 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
         )
 
     def _get_spatial_padding_same(self, shape):
-        return tuple(
+        return [
             _compute_padding(stride, dilation_rate, shape[i], filter_size)
             for i, (stride, dilation_rate, filter_size) in enumerate(
                 zip(self.strides, self.dilation_rate, self.kernel_size)
             )
-        )
+        ]
 
     def _get_spatial_shape(self, input_shape):
         return (
@@ -119,9 +119,9 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
         input_shape = tf.shape(inputs)
         padding = self._get_spatial_padding_same(self._get_spatial_shape(input_shape))
         return (
-            ((0, 0), *padding, (0, 0))
+            [[0, 0], *padding, [0, 0]]
             if self.data_format == "channels_last"
-            else ((0, 0), (0, 0), *padding)
+            else [[0, 0], [0, 0], *padding]
         )
 
     def _get_padding_same_shape(self, input_shape):

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -209,16 +209,17 @@ class TestLayers:
     @pytest.mark.parametrize(
         "layer_cls, input_shape",
         [
-            (lq.layers.QuantConv1D, (None, None, 3)),
-            (lq.layers.QuantConv2D, (None, None, None, 3)),
-            (lq.layers.QuantConv3D, (None, None, None, None, 3)),
-            (lq.layers.QuantSeparableConv1D, (None, None, 3)),
-            (lq.layers.QuantSeparableConv2D, (None, None, None, 3)),
-            (lq.layers.QuantDepthwiseConv2D, (None, None, None, 3)),
+            (lq.layers.QuantConv1D, (None, 3)),
+            (lq.layers.QuantConv2D, (None, None, 3)),
+            (lq.layers.QuantConv3D, (None, None, None, 3)),
+            (lq.layers.QuantSeparableConv1D, (None, 3)),
+            (lq.layers.QuantSeparableConv2D, (None, None, 3)),
+            (lq.layers.QuantDepthwiseConv2D, (None, None, 3)),
         ],
     )
     def test_non_zero_padding_unknown_inputs(self, layer_cls, input_shape):
-        layer_cls(16, 3, padding="same", pad_values=1.0).build(input_shape)
+        input = tf.keras.layers.Input(shape=input_shape)
+        layer_cls(16, 3, padding="same", pad_values=1.0)(input)
 
 
 class TestLayerWarns:

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -217,9 +217,12 @@ class TestLayers:
             (lq.layers.QuantDepthwiseConv2D, (None, None, 3)),
         ],
     )
-    def test_non_zero_padding_unknown_inputs(self, layer_cls, input_shape):
+    @pytest.mark.parametrize("data_format", ["channels_last", "channels_first"])
+    def test_non_zero_padding_unknown_inputs(self, layer_cls, input_shape, data_format):
+        if data_format == "channels_first":
+            input_shape = reversed(input_shape)
         input = tf.keras.layers.Input(shape=input_shape)
-        layer_cls(16, 3, padding="same", pad_values=1.0)(input)
+        layer_cls(16, 3, padding="same", pad_values=1.0, data_format=data_format)(input)
 
 
 class TestLayerWarns:

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -206,6 +206,20 @@ class TestLayers:
         assert layer(inputs).shape == ref_layer(inputs).shape
         spy.assert_called_once_with(mocker.ANY, mocker.ANY, constant_values=1.0)
 
+    @pytest.mark.parametrize(
+        "layer_cls, input_shape",
+        [
+            (lq.layers.QuantConv1D, (None, None, 3)),
+            (lq.layers.QuantConv2D, (None, None, None, 3)),
+            (lq.layers.QuantConv3D, (None, None, None, None, 3)),
+            (lq.layers.QuantSeparableConv1D, (None, None, 3)),
+            (lq.layers.QuantSeparableConv2D, (None, None, None, 3)),
+            (lq.layers.QuantDepthwiseConv2D, (None, None, None, 3)),
+        ],
+    )
+    def test_non_zero_padding_unknown_inputs(self, layer_cls, input_shape):
+        layer_cls(16, 3, padding="same", pad_values=1.0).build(input_shape)
+
 
 class TestLayerWarns:
     def test_layer_warns(self, caplog):


### PR DESCRIPTION
This makes sure that `Layer.build` doesn't throw when input shapes are undefined.