### PR TITLE
Use static tensor shapes if possible for one-padding

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -116,7 +116,9 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
         )
 
     def _get_padding_same(self, inputs):
-        input_shape = tf.shape(inputs)
+        input_shape = inputs.shape
+        if not input_shape[1:].is_fully_defined():
+            input_shape = tf.shape(inputs)
         padding = self._get_spatial_padding_same(self._get_spatial_shape(input_shape))
         return (
             [[0, 0], *padding, [0, 0]]

--- a/larq/models_test.py
+++ b/larq/models_test.py
@@ -23,6 +23,7 @@ def get_profile_model():
                 input_quantizer=lq.quantizers.SteTern(),
                 depthwise_quantizer=lq.quantizers.SteTern(),
                 padding="same",
+                pad_values=1.0,
                 use_bias=False,
             ),
             tf.keras.layers.BatchNormalization(scale=False),


### PR DESCRIPTION
In general the batch dimension is undefined. This means that [`tf.pad`](https://github.com/tensorflow/tensorflow/blob/r2.1/tensorflow/python/ops/array_ops.py#L2952-L2968) doesn't correctly set the shapes of the tensor. This makes model summary fail since the `TensorShape` is not correctly inferred.

This PR uses static shapes whenever the spatial dimensions are fully defined to avoid this problem.