### PR TITLE
Add support for experimental_aggregate_gradients

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0, 2.2.0rc0]
+        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0, 2.2.0rc2]
 
     steps:
       - uses: actions/checkout@v2

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -138,12 +138,15 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
                 grad_var_lists[self.var_opt_mapping[var.name]].append((grad, var))
 
         # Apply gradients to each optimizer
-        train_ops = [
-            optimizer.apply_gradients(opt_grads_and_vars)
-            for optimizer, opt_grads_and_vars in zip(self.optimizers, grad_var_lists)
-        ]
+        with tf.name_scope(self._name):
+            train_ops = [
+                optimizer.apply_gradients(opt_grads_and_vars)
+                for optimizer, opt_grads_and_vars in zip(
+                    self.optimizers, grad_var_lists
+                )
+            ]
 
-        return tf.group(*train_ops, name="train_with_group")
+            return tf.group(*train_ops, name=name or "train_with_group")
 
     def get_config(self):
         optimizer_configs = [opt.get_config() for (_, opt) in self.pred_opt_pairs]

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -299,9 +299,6 @@ class Bop(tf.keras.optimizers.Optimizer):
         var_t = lq.math.sign(-tf.sign(var * m_t - threshold) * var)
         return var.assign(var_t).op
 
-    def _resource_apply_sparse(self, grad, var, indices):
-        raise NotImplementedError()
-
     def get_config(self):
         config = {
             "threshold": self._serialize_hyperparameter("threshold"),

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -66,6 +66,8 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
         not claimed by any other optimizer. (Must be passed as keyword argument.)
     """
 
+    _HAS_AGGREGATE_GRAD = True
+
     def __init__(
         self,
         *predicate_optimizer_pairs: Tuple[
@@ -118,7 +120,7 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             weights.extend(optimizer.weights)
         return weights
 
-    def apply_gradients(self, grads_and_vars, name: Optional[str] = None):
+    def apply_gradients(self, grads_and_vars, name: Optional[str] = None, **kwargs):
         """Apply gradients to variables for each optimizer.
 
         On the first call to `apply_gradients()`, compute the mapping from variables to
@@ -140,7 +142,7 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
         # Apply gradients to each optimizer
         with tf.name_scope(self._name):
             train_ops = [
-                optimizer.apply_gradients(opt_grads_and_vars)
+                optimizer.apply_gradients(opt_grads_and_vars, **kwargs)
                 for optimizer, opt_grads_and_vars in zip(
                     self.optimizers, grad_var_lists
                 )
@@ -265,6 +267,8 @@ class Bop(tf.keras.optimizers.Optimizer):
     # References
     - [Latent Weights Do Not Exist: Rethinking Binarized Neural Network Optimization](https://papers.nips.cc/paper/8971-latent-weights-do-not-exist-rethinking-binarized-neural-network-optimization)
     """
+
+    _HAS_AGGREGATE_GRAD = True
 
     def __init__(
         self, threshold: float = 1e-8, gamma: float = 1e-4, name: str = "Bop", **kwargs

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -213,6 +213,14 @@ class TestBopOptimizer:
             target=0,
         )
 
+    def test_mixed_precision(self):
+        opt = lq.optimizers.CaseOptimizer(
+            (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
+            default_optimizer=tf.keras.optimizers.Adam(0.01),
+        )
+        opt = tf.keras.mixed_precision.experimental.LossScaleOptimizer(opt, "dynamic")
+        _test_optimizer(opt, test_kernels_are_binary=True)
+
     def test_bop_tf_1_14_schedules(self):
         _test_optimizer(
             lq.optimizers.CaseOptimizer(


### PR DESCRIPTION
This PR adds support for `experimental_aggregate_gradients` in `apply_gradients` for `Bop` and the `CaseOptimizer` which will be introduced in TensorFlow 2.2

[`experimental_aggregate_gradients=False`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/optimizer_v2/optimizer_v2.py#L434-L473) allows users to aggregate gradients themselfs. E.g. this is use by [Keras to manually aggregate scaled gradients in fp16 when using multi-GPU mixed precision training before passing them to the optimizer](https://github.com/tensorflow/tensorflow/blob/b97c90c87fc433140bae47d93521a3b795645c12/tensorflow/python/keras/engine/training.py#L1822-L1845).

Adding support for it also works around a bug in TF 2.2-rc2 where in mixed precision training [`_HAS_AGGREGATE_GRAD` is not checked so `experimental_aggregate_gradients` is always passed to the wrapped optimizer](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/mixed_precision/experimental/loss_scale_optimizer.py#L275-L282) which would fail with a cryptic error message otherwise.

Since the keyword argument might change in the future, I just forward `**kwargs` to the underlying optimizers.

This PR also adds the correct name scopes in `apply_gradients` which previously weren't used.