### PR TITLE
Implement compute_output_shape in base quantizer

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -166,6 +166,9 @@ class BaseQuantizer(tf.keras.layers.Layer):
     def non_trainable_weights(self):
         return []
 
+    def compute_output_shape(self, input_shape):
+        return input_shape
+
 
 @utils.register_keras_custom_object
 class NoOp(BaseQuantizer):


### PR DESCRIPTION
Keras might call layers to figure out the output shapes. Implementing `compute_output_shape` allows for static shape inference in the keras graph without needing to actually call the layer.