### PR TITLE
Fix larq summary for subclassed models

### DIFF
--- a/larq/models.py
+++ b/larq/models.py
@@ -222,7 +222,7 @@ class LayerProfile:
             return "?"
 
     @property
-    def output_pixels(self) -> int:
+    def output_pixels(self) -> Optional[int]:
         """Number of pixels for a single feature map (1 for fully connected layers)."""
         if not self.output_shape:
             return None

--- a/larq/models.py
+++ b/larq/models.py
@@ -150,7 +150,7 @@ class LayerProfile:
 
         self.op_profiles = []
 
-        if isinstance(layer, mac_containing_layers):
+        if isinstance(layer, mac_containing_layers) and self.output_pixels:
             for p in self.weight_profiles:
                 if not p.is_bias():
                     self.op_profiles.append(
@@ -224,12 +224,13 @@ class LayerProfile:
     @property
     def output_pixels(self) -> int:
         """Number of pixels for a single feature map (1 for fully connected layers)."""
+        if not self.output_shape:
+            return None
         if len(self.output_shape) == 4:
             return int(np.prod(self.output_shape[1:3]))
-        elif len(self.output_shape) == 2:
+        if len(self.output_shape) == 2:
             return 1
-        else:
-            raise NotImplementedError()
+        raise NotImplementedError()
 
     @property
     def unique_param_bidtwidths(self) -> Sequence[int]:

--- a/larq/models.py
+++ b/larq/models.py
@@ -190,7 +190,10 @@ class LayerProfile:
         if op_type != "mac":
             raise ValueError("Currently only counting of MAC-operations is supported.")
 
-        if isinstance(self._layer, op_count_supported_layer_types):
+        if (
+            isinstance(self._layer, op_count_supported_layer_types)
+            and self.output_pixels
+        ):
             count = 0
             for op in self.op_profiles:
                 if (precision is None or op.precision == precision) and (

--- a/larq/snapshots/snap_models_test.py
+++ b/larq/snapshots/snap_models_test.py
@@ -54,3 +54,25 @@ snapshots['test_summary 2'] = '''+sequential_1 stats--------------------+
 | Number of MACs                 0      |
 +---------------------------------------+
 '''
+
+snapshots['test_subclass_model_summary 1'] = '''+toy_model stats-------------------------------------------------------------+
+| Layer                     Input prec.   Outputs  # 1-bit  # 32-bit  Memory |
+|                                 (bit)                x 1       x 1    (kB) |
++----------------------------------------------------------------------------+
+| quant_conv2d                        -  multiple      864        32    0.23 |
+| global_average_pooling2d            -  multiple        0         0       0 |
+| dense                               -  multiple        0       330    1.29 |
++----------------------------------------------------------------------------+
+| Total                                                864       362    1.52 |
++----------------------------------------------------------------------------+
++toy_model summary------------------------+
+| Total params                   1.23 k   |
+| Trainable params               1.23 k   |
+| Non-trainable params           0        |
+| Model size                     1.52 KiB |
+| Model size (8-bit FP weights)  470.00 B |
+| Float-32 Equivalent            4.79 KiB |
+| Compression Ratio of Memory    0.32     |
+| Number of MACs                 0        |
++-----------------------------------------+
+'''


### PR DESCRIPTION
This PR makes sure that `lq.models.summary` can be called on subclassed models.

This fixes #479 which was introduced in #157.

@koenhelwegen I am not 100% how the statistics are calculated, can I just ignore them if the output shape of a layer is undefined?