### PR TITLE
Reformat docs for keras-autodoc

### DIFF
--- a/larq/activations.py
+++ b/larq/activations.py
@@ -35,10 +35,10 @@ def hard_tanh(x: tf.Tensor) -> tf.Tensor:
     ```
 
     # Arguments
-    x: Input tensor.
+        x: Input tensor.
 
     # Returns
-    Hard tanh activation.
+        Hard tanh activation.
     """
     return tf.clip_by_value(x, -1, 1)
 
@@ -53,11 +53,11 @@ def leaky_tanh(x: tf.Tensor, alpha: float = 0.2) -> tf.Tensor:
     ```
 
     # Arguments
-    x: Input tensor.
-    alpha: Slope of the activation function outside of [-1, 1].
+        x: Input tensor.
+        alpha: Slope of the activation function outside of [-1, 1].
 
     # Returns
-    Leaky tanh activation.
+        Leaky tanh activation.
     """
     return (
         tf.clip_by_value(x, -1, 1)

--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -17,18 +17,19 @@ class HyperparameterScheduler(keras.callbacks.Callback):
             HyperparameterScheduler(lambda x: 0.001 * (0.1 ** (x // 30)), "gamma", bop)
         ]
         ```
+
     # Arguments
-    schedule: a function that takes an epoch index as input
-        (integer, indexed from 0) and returns a new hyperparameter as output.
-    hyperparameter: str. the name of the hyperparameter to be scheduled.
-    optimizer: the optimizer that contains the hyperparameter that will be scheduled.
-        Defaults to `self.model.optimizer` if `optimizer == None`.
-    update_freq: str (optional), denotes on what update_freq to change the
-        hyperparameter. Can be either "epoch" (default) or "step".
-    verbose: int. 0: quiet, 1: update messages.
-    log_name: str (optional), under which name to log this hyperparameter to
-        Tensorboard. If `None`, defaults to `hyperparameter`. Use this if you have
-        several schedules for the same hyperparameter on different optimizers.
+        schedule: a function that takes an epoch index as input
+            (integer, indexed from 0) and returns a new hyperparameter as output.
+        hyperparameter: str. the name of the hyperparameter to be scheduled.
+        optimizer: the optimizer that contains the hyperparameter that will be scheduled.
+            Defaults to `self.model.optimizer` if `optimizer == None`.
+        update_freq: str (optional), denotes on what update_freq to change the
+            hyperparameter. Can be either "epoch" (default) or "step".
+        verbose: int. 0: quiet, 1: update messages.
+        log_name: str (optional), under which name to log this hyperparameter to
+            Tensorboard. If `None`, defaults to `hyperparameter`. Use this if you have
+            several schedules for the same hyperparameter on different optimizers.
     """
 
     def __init__(

--- a/larq/constraints.py
+++ b/larq/constraints.py
@@ -33,7 +33,7 @@ class WeightClip(tf.keras.constraints.Constraint):
     to be between `[-clip_value, clip_value]`.
 
     # Arguments
-    clip_value: The value to clip incoming weights.
+        clip_value: The value to clip incoming weights.
     """
 
     def __init__(self, clip_value: float = 1):

--- a/larq/context.py
+++ b/larq/context.py
@@ -31,7 +31,7 @@ def quantized_scope(quantize):
 
     # Arguments
         quantize: If `should_quantize` is `True`, `QuantizedVariable` will return their
-            quantized value in the forward pass. If `False`, `QuantizedVariable` will 
+            quantized value in the forward pass. If `False`, `QuantizedVariable` will
             act as a latent variable.
     """
     backup = should_quantize()

--- a/larq/context.py
+++ b/larq/context.py
@@ -30,9 +30,9 @@ def quantized_scope(quantize):
         ```
 
     # Arguments
-    quantize: If `should_quantize` is `True`, `QuantizedVariable` will return their
-        quantized value in the forward pass. If `False`, `QuantizedVariable` will act
-        as a latent variable.
+        quantize: If `should_quantize` is `True`, `QuantizedVariable` will return their
+            quantized value in the forward pass. If `False`, `QuantizedVariable` will 
+            act as a latent variable.
     """
     backup = should_quantize()
     _quantized_scope.should_quantize = quantize
@@ -63,8 +63,8 @@ def metrics_scope(metrics=[]):
         ```
 
     # Arguments
-    metrics: Iterable of metrics to add to quantizers defined inside this context.
-        Currently only the `flip_ratio` metric is available.
+        metrics: Iterable of metrics to add to quantizers defined inside this context.
+            Currently only the `flip_ratio` metric is available.
     """
     for metric in metrics:
         if metric not in _available_metrics:
@@ -91,6 +91,6 @@ def get_training_metrics():
         ```
 
     # Returns
-    A set of training metrics in the current scope.
+        A set of training metrics in the current scope.
     """
     return _global_training_metrics

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -63,28 +63,29 @@ class QuantDense(QuantizerBase, tf.keras.layers.Dense):
         ```
 
     # Arguments
-    units: Positive integer, dimensionality of the output space.
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the `kernel` weights matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        units: Positive integer, dimensionality of the output space.
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the `kernel` weights matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     # Input shape
-    N-D tensor with shape: `(batch_size, ..., input_dim)`. The most common situation
-    would be a 2D input with shape `(batch_size, input_dim)`.
+        N-D tensor with shape: `(batch_size, ..., input_dim)`. The most common situation
+        would be a 2D input with shape `(batch_size, input_dim)`.
 
     # Output shape
-    N-D tensor with shape: `(batch_size, ..., units)`. For instance, for a 2D input with
-    shape `(batch_size, input_dim)`, the output would have shape `(batch_size, units)`.
+        N-D tensor with shape: `(batch_size, ..., units)`. For instance, for a 2D input
+        with shape `(batch_size, input_dim)`, the output would have shape
+        `(batch_size, units)`.
     """
 
     def __init__(
@@ -138,43 +139,44 @@ class QuantConv1D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv1D):
     sequences of 128-dimensional vectors.
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of a single integer,
-        specifying the length of the 1D convolution window.
-    strides: An integer or tuple/list of a single integer, specifying the stride
-        length of the convolution. Specifying any stride value != 1 is incompatible
-        with specifying any `dilation_rate` value != 1.
-    padding: One of `"valid"`, `"causal"` or `"same"` (case-insensitive). `"causal"`
-        results in causal (dilated) convolutions, e.g. output[t] does not depend on
-        input[t+1:]. Useful when modeling temporal data where the model should not
-        violate the temporal order. See [WaveNet: A Generative Model for Raw Audio,
-            section 2.1](https://arxiv.org/abs/1609.03499).
-    pad_values: The pad value to use when `padding="same"`.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-    dilation_rate: an integer or tuple/list of a single integer, specifying the dilation
-        rate to use for dilated convolution. Currently, specifying any `dilation_rate`
-        value != 1 is incompatible with specifying any `strides` value != 1.
-    activation: Activation function to use. If you don't specify anything, no activation
-        is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of a single integer,
+            specifying the length of the 1D convolution window.
+        strides: An integer or tuple/list of a single integer, specifying the stride
+            length of the convolution. Specifying any stride value != 1 is incompatible
+            with specifying any `dilation_rate` value != 1.
+        padding: One of `"valid"`, `"causal"` or `"same"` (case-insensitive). `"causal"`
+            results in causal (dilated) convolutions, e.g. output[t] does not depend on
+            input[t+1:]. Useful when modeling temporal data where the model should not
+            violate the temporal order. See [WaveNet: A Generative Model for Raw Audio,
+                section 2.1](https://arxiv.org/abs/1609.03499).
+        pad_values: The pad value to use when `padding="same"`.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+        dilation_rate: an integer or tuple/list of a single integer, specifying the
+            dilation rate to use for dilated convolution. Currently, specifying any
+            `dilation_rate` value != 1 is incompatible with specifying any `strides`
+            value != 1.
+        activation: Activation function to use. If you don't specify anything, no
+            activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the kernel matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     # Input shape
-    3D tensor with shape: `(batch_size, steps, input_dim)`
+        3D tensor with shape: `(batch_size, steps, input_dim)`
 
     # Output shape
-    3D tensor with shape: `(batch_size, new_steps, filters)`.
-    `steps` value might have changed due to padding or strides.
+        3D tensor with shape: `(batch_size, new_steps, filters)`.
+        `steps` value might have changed due to padding or strides.
     """
 
     def __init__(
@@ -240,53 +242,54 @@ class QuantConv2D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv2D):
     `data_format="channels_last"`.
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of 2 integers, specifying the
-        height and width of the 2D convolution window. Can be a single integer
-        to specify the same value for all spatial dimensions.
-    strides: An integer or tuple/list of 2 integers, specifying the strides of
-        the convolution along the height and width. Can be a single integer to
-        specify the same value for all spatial dimensions. Specifying any stride
-        value != 1 is incompatible with specifying any `dilation_rate` value != 1.
-    padding: one of `"valid"` or `"same"` (case-insensitive).
-    pad_values: The pad value to use when `padding="same"`.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-        The ordering of the dimensions in the inputs. `channels_last` corresponds to
-        inputs with shape `(batch, height, width, channels)` while `channels_first`
-        corresponds to inputs with shape `(batch, channels, height, width)`. It defaults
-        to the `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
-    dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation rate
-        to use for dilated convolution. Can be a single integer to specify the same
-        value for all spatial dimensions. Currently, specifying any `dilation_rate`
-        value != 1 is incompatible with specifying any stride value != 1.
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of 2 integers, specifying the
+            height and width of the 2D convolution window. Can be a single integer
+            to specify the same value for all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers, specifying the strides of
+            the convolution along the height and width. Can be a single integer to
+            specify the same value for all spatial dimensions. Specifying any stride
+            value != 1 is incompatible with specifying any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        pad_values: The pad value to use when `padding="same"`.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs. `channels_last` corresponds to
+            inputs with shape `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape `(batch, channels, height, width)`. It
+            defaults to the `image_data_format` value found in your Keras config file at
+            `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
+        dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation
+            rate to use for dilated convolution. Can be a single integer to specify the
+            same value for all spatial dimensions. Currently, specifying any
+            `dilation_rate` value != 1 is incompatible with specifying any stride value
+            != 1.
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the kernel matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     # Input shape
-    4D tensor with shape:
-    `(samples, channels, rows, cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(samples, rows, cols, channels)` if data_format='channels_last'.
+        4D tensor with shape:
+        `(samples, channels, rows, cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(samples, rows, cols, channels)` if data_format='channels_last'.
 
     # Output shape
-    4D tensor with shape:
-    `(samples, filters, new_rows, new_cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(samples, new_rows, new_cols, filters)` if data_format='channels_last'.
-    `rows` and `cols` values might have changed due to padding.
+        4D tensor with shape:
+        `(samples, filters, new_rows, new_cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(samples, new_rows, new_cols, filters)` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
     """
 
     def __init__(
@@ -352,59 +355,61 @@ class QuantConv3D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv3D):
     with a single channel, in `data_format="channels_last"`.
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of 3 integers, specifying the
-        depth, height and width of the 3D convolution window. Can be a single
-        integer to specify the same value for all spatial dimensions.
-    strides: An integer or tuple/list of 3 integers, specifying the strides of the
-        convolution along each spatial dimension. Can be a single integer to specify the
-        same value for all spatial dimensions. Specifying any stride value != 1 is
-        incompatible with specifying any `dilation_rate` value != 1.
-    padding: one of `"valid"` or `"same"` (case-insensitive).
-    pad_values: The pad value to use when `padding="same"`.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-        The ordering of the dimensions in the inputs. `channels_last` corresponds to
-        inputs with shape `(batch, spatial_dim1, spatial_dim2, spatial_dim3, channels)`
-        while `channels_first` corresponds to inputs with shape
-        `(batch, channels, spatial_dim1, spatial_dim2, spatial_dim3)`. It defaults to
-        the `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
-    dilation_rate: an integer or tuple/list of 3 integers, specifying the dilation rate
-        to use for dilated convolution. Can be a single integer to specify the same
-        value for all spatial dimensions. Currently, specifying any `dilation_rate`
-        value != 1 is incompatible with specifying any stride value != 1.
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of 3 integers, specifying the
+            depth, height and width of the 3D convolution window. Can be a single
+            integer to specify the same value for all spatial dimensions.
+        strides: An integer or tuple/list of 3 integers, specifying the strides of the
+            convolution along each spatial dimension. Can be a single integer to specify
+            the same value for all spatial dimensions. Specifying any stride value != 1
+            is incompatible with specifying any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        pad_values: The pad value to use when `padding="same"`.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs. `channels_last` corresponds to
+            inputs with shape
+            `(batch, spatial_dim1, spatial_dim2, spatial_dim3, channels)` while
+            `channels_first` corresponds to inputs with shape
+            `(batch, channels, spatial_dim1, spatial_dim2, spatial_dim3)`. It defaults
+            to the `image_data_format` value found in your Keras config file at
+            `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
+        dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation
+            rate to use for dilated convolution. Can be a single integer to specify the
+            same value for all spatial dimensions. Currently, specifying any
+            `dilation_rate` value != 1 is incompatible with specifying any stride value
+            != 1.
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the kernel matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     # Input shape
-    5D tensor with shape:
-    `(samples, channels, conv_dim1, conv_dim2, conv_dim3)` if
-        data_format='channels_first'
-    or 5D tensor with shape:
-    `(samples, conv_dim1, conv_dim2, conv_dim3, channels)` if
-        data_format='channels_last'.
+        5D tensor with shape:
+        `(samples, channels, conv_dim1, conv_dim2, conv_dim3)` if
+            data_format='channels_first'
+        or 5D tensor with shape:
+        `(samples, conv_dim1, conv_dim2, conv_dim3, channels)` if
+            data_format='channels_last'.
 
     # Output shape
-    5D tensor with shape:
-    `(samples, filters, new_conv_dim1, new_conv_dim2, new_conv_dim3)` if
-        data_format='channels_first'
-    or 5D tensor with shape:
-    `(samples, new_conv_dim1, new_conv_dim2, new_conv_dim3, filters)` if
-        data_format='channels_last'.
-    `new_conv_dim1`, `new_conv_dim2` and `new_conv_dim3` values might have
-        changed due to padding.
+        5D tensor with shape:
+        `(samples, filters, new_conv_dim1, new_conv_dim2, new_conv_dim3)` if
+            data_format='channels_first'
+        or 5D tensor with shape:
+        `(samples, new_conv_dim1, new_conv_dim2, new_conv_dim3, filters)` if
+            data_format='channels_last'.
+        `new_conv_dim1`, `new_conv_dim2` and `new_conv_dim3` values might have
+            changed due to padding.
     """
 
     def __init__(
@@ -463,52 +468,54 @@ class QuantDepthwiseConv2D(
     input channel in the depthwise step.
 
     # Arguments
-    kernel_size: An integer or tuple/list of 2 integers, specifying the height and width
-        of the 2D convolution window. Can be a single integer to specify the same value
-        for all spatial dimensions.
-    strides: An integer or tuple/list of 2 integers, specifying the strides of the
-        convolution along the height and width. Can be a single integer to specify the
-        same value for all spatial dimensions. Specifying any stride value != 1 is
-        incompatible with specifying any `dilation_rate` value != 1.
-    padding: one of `'valid'` or `'same'` (case-insensitive).
-    pad_values: The pad value to use when `padding="same"`.
-    depth_multiplier: The number of depthwise convolution output channels for each input
-        channel. The total number of depthwise convolution output channels will be equal
-        to `filters_in * depth_multiplier`.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-        The ordering of the dimensions in the inputs. `channels_last` corresponds to
-        inputs with shape `(batch, height, width, channels)` while `channels_first`
-        corresponds to inputs with shape `(batch, channels, height, width)`.
-        It defaults to the `image_data_format` value found in your
-        Keras config file at `~/.keras/keras.json`.
-        If you never set it, then it will be 'channels_last'.
-    activation: Activation function to use.
-        If you don't specify anything, no activation is applied (ie. `a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    depthwise_quantizer: Quantization function applied to the `depthwise_kernel`
-        weights matrix.
-    depthwise_initializer: Initializer for the depthwise kernel matrix.
-    bias_initializer: Initializer for the bias vector.
-    depthwise_regularizer: Regularizer function applied to the depthwise kernel matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its 'activation').
-    depthwise_constraint: Constraint function applied to the depthwise kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        kernel_size: An integer or tuple/list of 2 integers, specifying the height and
+            width of the 2D convolution window. Can be a single integer to specify the
+            same value for all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers, specifying the strides of the
+            convolution along the height and width. Can be a single integer to specify
+            the same value for all spatial dimensions. Specifying any stride value != 1
+            is incompatible with specifying any `dilation_rate` value != 1.
+        padding: one of `'valid'` or `'same'` (case-insensitive).
+        pad_values: The pad value to use when `padding="same"`.
+        depth_multiplier: The number of depthwise convolution output channels for each
+            input channel. The total number of depthwise convolution output channels
+            will be equal to `filters_in * depth_multiplier`.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs. `channels_last` corresponds to
+            inputs with shape `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape `(batch, channels, height, width)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be 'channels_last'.
+        activation: Activation function to use.
+            If you don't specify anything, no activation is applied (ie. `a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        depthwise_quantizer: Quantization function applied to the `depthwise_kernel`
+            weights matrix.
+        depthwise_initializer: Initializer for the depthwise kernel matrix.
+        bias_initializer: Initializer for the bias vector.
+        depthwise_regularizer: Regularizer function applied to the depthwise kernel
+            matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its 'activation').
+        depthwise_constraint: Constraint function applied to the depthwise kernel
+            matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     # Input shape
-    4D tensor with shape:
-    `[batch, channels, rows, cols]` if data_format='channels_first'
-    or 4D tensor with shape:
-    `[batch, rows, cols, channels]` if data_format='channels_last'.
+        4D tensor with shape:
+        `[batch, channels, rows, cols]` if data_format='channels_first'
+        or 4D tensor with shape:
+        `[batch, rows, cols, channels]` if data_format='channels_last'.
 
     # Output shape
-    4D tensor with shape:
-    `[batch, filters, new_rows, new_cols]` if data_format='channels_first'
-    or 4D tensor with shape:
-    `[batch, new_rows, new_cols, filters]` if data_format='channels_last'.
-    `rows` and `cols` values might have changed due to padding.
+        4D tensor with shape:
+        `[batch, filters, new_rows, new_cols]` if data_format='channels_first'
+        or 4D tensor with shape:
+        `[batch, new_rows, new_cols, filters]` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
     """
 
     def __init__(
@@ -569,50 +576,52 @@ class QuantSeparableConv1D(
     It then optionally applies an activation function to produce the final output.
 
     # Arguments
-    filters: Integer, the dimensionality of the output space (i.e. the number
-        of filters in the convolution).
-    kernel_size: A single integer specifying the spatial dimensions of the filters.
-    strides: A single integer specifying the strides of the convolution.
-        Specifying any `stride` value != 1 is incompatible with specifying
-        any `dilation_rate` value != 1.
-    padding: One of `"valid"`, `"same"`, or `"causal"` (case-insensitive).
-    pad_values: The pad value to use when `padding="same"`.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-        The ordering of the dimensions in the inputs. `channels_last` corresponds
-        to inputs with shape `(batch, length, channels)` while `channels_first`
-        corresponds to inputs with shape `(batch, channels, length)`.
-    dilation_rate: A single integer, specifying the dilation rate to use for dilated
-        convolution. Currently, specifying any `dilation_rate` value != 1 is
-        incompatible with specifying any stride value != 1.
-    depth_multiplier: The number of depthwise convolution output channels for
-        each input channel. The total number of depthwise convolution output
-        channels will be equal to `num_filters_in * depth_multiplier`.
-    activation: Activation function. Set it to None to maintain a linear activation.
-    use_bias: Boolean, whether the layer uses a bias.
-    input_quantizer: Quantization function applied to the input of the layer.
-    depthwise_quantizer: Quantization function applied to the depthwise kernel.
-    pointwise_quantizer: Quantization function applied to the pointwise kernel.
-    depthwise_initializer: An initializer for the depthwise convolution kernel.
-    pointwise_initializer: An initializer for the pointwise convolution kernel.
-    bias_initializer: An initializer for the bias vector. If None, the default
-        initializer will be used.
-    depthwise_regularizer: Optional regularizer for the depthwise convolution kernel.
-    pointwise_regularizer: Optional regularizer for the pointwise convolution kernel.
-    bias_regularizer: Optional regularizer for the bias vector.
-    activity_regularizer: Optional regularizer function for the output.
-    depthwise_constraint: Optional projection function to be applied to the
-        depthwise kernel after being updated by an `Optimizer`
-        (e.g. used for norm constraints or value constraints for layer weights).
-        The function must take as input the unprojected variable and must return
-        the projected variable (which must have the same shape). Constraints are
-        not safe to use when doing asynchronous distributed training.
-    pointwise_constraint: Optional projection function to be applied to the
-        pointwise kernel after being updated by an `Optimizer`.
-    bias_constraint: Optional projection function to be applied to the
-        bias after being updated by an `Optimizer`.
-    trainable: Boolean, if `True` the weights of this layer will be marked as
-        trainable (and listed in `layer.trainable_weights`).
-    name: A string, the name of the layer.
+        filters: Integer, the dimensionality of the output space (i.e. the number
+            of filters in the convolution).
+        kernel_size: A single integer specifying the spatial dimensions of the filters.
+        strides: A single integer specifying the strides of the convolution.
+            Specifying any `stride` value != 1 is incompatible with specifying
+            any `dilation_rate` value != 1.
+        padding: One of `"valid"`, `"same"`, or `"causal"` (case-insensitive).
+        pad_values: The pad value to use when `padding="same"`.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs. `channels_last` corresponds
+            to inputs with shape `(batch, length, channels)` while `channels_first`
+            corresponds to inputs with shape `(batch, channels, length)`.
+        dilation_rate: A single integer, specifying the dilation rate to use for dilated
+            convolution. Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any stride value != 1.
+        depth_multiplier: The number of depthwise convolution output channels for
+            each input channel. The total number of depthwise convolution output
+            channels will be equal to `num_filters_in * depth_multiplier`.
+        activation: Activation function. Set it to None to maintain a linear activation.
+        use_bias: Boolean, whether the layer uses a bias.
+        input_quantizer: Quantization function applied to the input of the layer.
+        depthwise_quantizer: Quantization function applied to the depthwise kernel.
+        pointwise_quantizer: Quantization function applied to the pointwise kernel.
+        depthwise_initializer: An initializer for the depthwise convolution kernel.
+        pointwise_initializer: An initializer for the pointwise convolution kernel.
+        bias_initializer: An initializer for the bias vector. If None, the default
+            initializer will be used.
+        depthwise_regularizer: Optional regularizer for the depthwise convolution
+            kernel.
+        pointwise_regularizer: Optional regularizer for the pointwise convolution
+            kernel.
+        bias_regularizer: Optional regularizer for the bias vector.
+        activity_regularizer: Optional regularizer function for the output.
+        depthwise_constraint: Optional projection function to be applied to the
+            depthwise kernel after being updated by an `Optimizer`
+            (e.g. used for norm constraints or value constraints for layer weights).
+            The function must take as input the unprojected variable and must return
+            the projected variable (which must have the same shape). Constraints are
+            not safe to use when doing asynchronous distributed training.
+        pointwise_constraint: Optional projection function to be applied to the
+            pointwise kernel after being updated by an `Optimizer`.
+        bias_constraint: Optional projection function to be applied to the
+            bias after being updated by an `Optimizer`.
+        trainable: Boolean, if `True` the weights of this layer will be marked as
+            trainable (and listed in `layer.trainable_weights`).
+        name: A string, the name of the layer.
     """
 
     def __init__(
@@ -692,59 +701,67 @@ class QuantSeparableConv2D(
     or as an extreme version of an Inception block.
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of 2 integers, specifying the height and
-        width of the 2D convolution window. Can be a single integer to specify the
-        same value for all spatial dimensions.
-    strides: An integer or tuple/list of 2 integers, specifying the strides of the
-        convolution along the height and width. Can be a single integer to specify
-        the same value for all spatial dimensions. Specifying any stride value != 1
-        is incompatible with specifying any `dilation_rate` value != 1.
-    padding: one of `"valid"` or `"same"` (case-insensitive).
-    pad_values: The pad value to use when `padding="same"`.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-        The ordering of the dimensions in the inputs. `channels_last` corresponds to
-        inputs with shape `(batch, height, width, channels)` while `channels_first`
-        corresponds to inputs with shape `(batch, channels, height, width)`. It
-        defaults to the `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
-    dilation_rate: An integer or tuple/list of 2 integers, specifying the dilation rate
-        to use for dilated convolution. Currently, specifying any `dilation_rate`
-        value != 1 is incompatible with specifying any `strides` value != 1.
-    depth_multiplier: The number of depthwise convolution output channels for each
-        input channel. The total number of depthwise convolution output channels
-        will be equal to `filters_in * depth_multiplier`.
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    depthwise_quantizer: Quantization function applied to the depthwise kernel matrix.
-    pointwise_quantizer: Quantization function applied to the pointwise kernel matrix.
-    depthwise_initializer: Initializer for the depthwise kernel matrix.
-    pointwise_initializer: Initializer for the pointwise kernel matrix.
-    bias_initializer: Initializer for the bias vector.
-    depthwise_regularizer: Regularizer function applied to the depthwise kernel matrix.
-    pointwise_regularizer: Regularizer function applied to the pointwise kernel matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    depthwise_constraint: Constraint function applied to the depthwise kernel matrix.
-    pointwise_constraint: Constraint function applied to the pointwise kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of 2 integers, specifying the height and
+            width of the 2D convolution window. Can be a single integer to specify the
+            same value for all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers, specifying the strides of the
+            convolution along the height and width. Can be a single integer to specify
+            the same value for all spatial dimensions. Specifying any stride value != 1
+            is incompatible with specifying any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        pad_values: The pad value to use when `padding="same"`.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs. `channels_last` corresponds to
+            inputs with shape `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape `(batch, channels, height, width)`. It
+            defaults to the `image_data_format` value found in your Keras config file at
+            `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
+        dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation
+            rate to use for dilated convolution. Can be a single integer to specify the
+            same value for all spatial dimensions. Currently, specifying any
+            `dilation_rate` value != 1 is incompatible with specifying any stride value
+            != 1.
+        depth_multiplier: The number of depthwise convolution output channels for each
+            input channel. The total number of depthwise convolution output channels
+            will be equal to `filters_in * depth_multiplier`.
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        depthwise_quantizer: Quantization function applied to the depthwise kernel
+            matrix.
+        pointwise_quantizer: Quantization function applied to the pointwise kernel
+            matrix.
+        depthwise_initializer: Initializer for the depthwise kernel matrix.
+        pointwise_initializer: Initializer for the pointwise kernel matrix.
+        bias_initializer: Initializer for the bias vector.
+        depthwise_regularizer: Regularizer function applied to the depthwise kernel
+            matrix.
+        pointwise_regularizer: Regularizer function applied to the pointwise kernel
+            matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        depthwise_constraint: Constraint function applied to the depthwise kernel
+            matrix.
+        pointwise_constraint: Constraint function applied to the pointwise kernel
+            matrix.
+        bias_constraint: Constraint function applied to the bias vector.`
 
     # Input shape
-    4D tensor with shape:
-    `(batch, channels, rows, cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(batch, rows, cols, channels)` if data_format='channels_last'.
+        4D tensor with shape:
+        `(batch, channels, rows, cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(batch, rows, cols, channels)` if data_format='channels_last'.
 
     # Output shape
-    4D tensor with shape:
-    `(batch, filters, new_rows, new_cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(batch, new_rows, new_cols, filters)` if data_format='channels_last'.
-    `rows` and `cols` values might have changed due to padding.
+        4D tensor with shape:
+        `(batch, filters, new_rows, new_cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(batch, new_rows, new_cols, filters)` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
     """
 
     def __init__(
@@ -820,58 +837,59 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
     `data_format="channels_last"`.
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of 2 integers, specifying the
-        height and width of the 2D convolution window. Can be a single integer
-        to specify the same value for all spatial dimensions.
-    strides: An integer or tuple/list of 2 integers, specifying the strides of
-        the convolution along the height and width. Can be a single integer to
-        specify the same value for all spatial dimensions. Specifying any stride
-        value != 1 is incompatible with specifying any `dilation_rate` value != 1.
-    padding: one of `"valid"` or `"same"` (case-insensitive).
-    output_padding: An integer or tuple/list of 2 integers, specifying the amount
-        of padding along the height and width of the output tensor. Can be a single
-        integer to specify the same value for all spatial dimensions. The amount of
-        output padding along a given dimension must be lower than the stride along
-        that same dimension.
-        If set to `None` (default), the output shape is inferred.
-    data_format: A string, one of `channels_last` (default) or `channels_first`. The
-        ordering of the dimensions in the inputs. `channels_last` corresponds to inputs
-        with shape `(batch, height, width, channels)` while `channels_first` corresponds
-        to inputs with shape `(batch, channels, height, width)`. It defaults to the
-        `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
-    dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation rate
-        to use for dilated convolution. Can be a single integer to specify the same
-        value for all spatial dimensions. Currently, specifying any `dilation_rate`
-        value != 1 is incompatible with specifying any stride value != 1.
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of 2 integers, specifying the
+            height and width of the 2D convolution window. Can be a single integer
+            to specify the same value for all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers, specifying the strides of
+            the convolution along the height and width. Can be a single integer to
+            specify the same value for all spatial dimensions. Specifying any stride
+            value != 1 is incompatible with specifying any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        output_padding: An integer or tuple/list of 2 integers, specifying the amount
+            of padding along the height and width of the output tensor. Can be a single
+            integer to specify the same value for all spatial dimensions. The amount of
+            output padding along a given dimension must be lower than the stride along
+            that same dimension.
+            If set to `None` (default), the output shape is inferred.
+        data_format: A string, one of `channels_last` (default) or `channels_first`. The
+            ordering of the dimensions in the inputs. `channels_last` corresponds to
+            inputs with shape `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape `(batch, channels, height, width)`. It
+            defaults to the `image_data_format` value found in your Keras config file at
+            `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
+        dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation
+            rate to use for dilated convolution. Can be a single integer to specify the
+            same value for all spatial dimensions. Currently, specifying any
+            `dilation_rate` value != 1 is incompatible with specifying any stride value
+            != 1.
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the kernel matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     # Input shape
-    4D tensor with shape:
-    `(batch, channels, rows, cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(batch, rows, cols, channels)` if data_format='channels_last'.
+        4D tensor with shape:
+        `(batch, channels, rows, cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(batch, rows, cols, channels)` if data_format='channels_last'.
 
     # Output shape
-    4D tensor with shape:
-    `(batch, filters, new_rows, new_cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(batch, new_rows, new_cols, filters)` if data_format='channels_last'.
-    `rows` and `cols` values might have changed due to padding.
+        4D tensor with shape:
+        `(batch, filters, new_rows, new_cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(batch, new_rows, new_cols, filters)` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
 
     # References
     - [A guide to convolution arithmetic for deep
@@ -943,57 +961,59 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
     if `data_format="channels_last"`.
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of 3 integers, specifying the depth, height
-        and width of the 3D convolution window. Can be a single integer to specify the
-        same value for all spatial dimensions.
-    strides: An integer or tuple/list of 3 integers, specifying the strides of the
-        convolution along the depth, height and width. Can be a single integer to
-        specify the same value for all spatial dimensions. Specifying any stride
-        value != 1 is incompatible with specifying any `dilation_rate` value != 1.
-    padding: one of `"valid"` or `"same"` (case-insensitive).
-    output_padding: An integer or tuple/list of 3 integers, specifying the amount
-        of padding along the depth, height, and width. Can be a single integer to
-        specify the same value for all spatial dimensions. The amount of output
-        padding along a given dimension must be lower than the stride along that
-        same dimension. If set to `None` (default), the output shape is inferred.
-    data_format: A string, one of `channels_last` (default) or `channels_first`. The
-        ordering of the dimensions in the inputs. `channels_last` corresponds to inputs
-        with shape `(batch, depth, height, width, channels)` while `channels_first`
-        corresponds to inputs with shape `(batch, channels, depth, height, width)`.
-        It defaults to the `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
-    dilation_rate: an integer or tuple/list of 3 integers, specifying the dilation
-        rate to use for dilated convolution. Can be a single integer to specify the
-        same value for all spatial dimensions. Currently, specifying any `dilation_rate`
-        value != 1 is incompatible with specifying any stride value != 1.
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of 3 integers, specifying the depth, height
+            and width of the 3D convolution window. Can be a single integer to specify the
+            same value for all spatial dimensions.
+        strides: An integer or tuple/list of 3 integers, specifying the strides of the
+            convolution along the depth, height and width. Can be a single integer to
+            specify the same value for all spatial dimensions. Specifying any stride
+            value != 1 is incompatible with specifying any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        output_padding: An integer or tuple/list of 3 integers, specifying the amount
+            of padding along the depth, height, and width. Can be a single integer to
+            specify the same value for all spatial dimensions. The amount of output
+            padding along a given dimension must be lower than the stride along that
+            same dimension. If set to `None` (default), the output shape is inferred.
+        data_format: A string, one of `channels_last` (default) or `channels_first`. The
+            ordering of the dimensions in the inputs. `channels_last` corresponds to
+            inputs with shape `(batch, depth, height, width, channels)` while
+            `channels_first` corresponds to inputs with shape
+            `(batch, channels, depth, height, width)`. It defaults to the
+            `image_data_format` value found in your Keras config file at
+            `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
+        dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation
+            rate to use for dilated convolution. Can be a single integer to specify the
+            same value for all spatial dimensions. Currently, specifying any
+            `dilation_rate` value != 1 is incompatible with specifying any stride value
+            != 1.
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the kernel matrix.
+        bias_constraint: Constraint function applied to the bias vector.
 
     # Input shape
-    5D tensor with shape:
-    `(batch, channels, depth, rows, cols)` if data_format='channels_first'
-    or 5D tensor with shape:
-    `(batch, depth, rows, cols, channels)` if data_format='channels_last'.
+        5D tensor with shape:
+        `(batch, channels, depth, rows, cols)` if data_format='channels_first'
+        or 5D tensor with shape:
+        `(batch, depth, rows, cols, channels)` if data_format='channels_last'.
 
     # Output shape
-    5D tensor with shape:
-    `(batch, filters, new_depth, new_rows, new_cols)` if data_format='channels_first'
-    or 5D tensor with shape:
-    `(batch, new_depth, new_rows, new_cols, filters)` if data_format='channels_last'.
-    `depth` and `rows` and `cols` values might have changed due to padding.
+        5D tensor with shape:
+        `(batch, filters, new_depth, new_rows, new_cols)` if data_format='channels_first'
+        or 5D tensor with shape:
+        `(batch, new_depth, new_rows, new_cols, filters)` if data_format='channels_last'.
+        `depth` and `rows` and `cols` values might have changed due to padding.
 
     # References
     - [A guide to convolution arithmetic for deep
@@ -1067,64 +1087,64 @@ class QuantLocallyConnected1D(QuantizerBase, tf.keras.layers.LocallyConnected1D)
         ```
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of a single integer,
-        specifying the length of the 1D convolution window.
-    strides: An integer or tuple/list of a single integer, specifying the stride
-        length of the convolution. Specifying any stride value != 1 is incompatible
-        with specifying any `dilation_rate` value != 1.
-    padding: Currently only supports `"valid"` (case-insensitive).
-        `"same"` may be supported in the future.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-        The ordering of the dimensions in the inputs. `channels_last` corresponds
-        to inputs with shape `(batch, length, channels)` while `channels_first`
-        corresponds to inputs with shape `(batch, channels, length)`. It defaults
-        to the `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
-    implementation: implementation mode, either `1` or `2`.
-        `1` loops over input spatial locations to perform the forward pass.
-        It is memory-efficient but performs a lot of (small) ops.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of a single integer,
+            specifying the length of the 1D convolution window.
+        strides: An integer or tuple/list of a single integer, specifying the stride
+            length of the convolution. Specifying any stride value != 1 is incompatible
+            with specifying any `dilation_rate` value != 1.
+        padding: Currently only supports `"valid"` (case-insensitive).
+            `"same"` may be supported in the future.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs. `channels_last` corresponds
+            to inputs with shape `(batch, length, channels)` while `channels_first`
+            corresponds to inputs with shape `(batch, channels, length)`. It defaults
+            to the `image_data_format` value found in your Keras config file at
+            `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the kernel matrix.
+        bias_constraint: Constraint function applied to the bias vector.
+        implementation: implementation mode, either `1` or `2`.
+            `1` loops over input spatial locations to perform the forward pass.
+            It is memory-efficient but performs a lot of (small) ops.
 
-        `2` stores layer weights in a dense but sparsely-populated 2D matrix
-        and implements the forward pass as a single matrix-multiply. It uses
-        a lot of RAM but performs few (large) ops.
+            `2` stores layer weights in a dense but sparsely-populated 2D matrix
+            and implements the forward pass as a single matrix-multiply. It uses
+            a lot of RAM but performs few (large) ops.
 
-        Depending on the inputs, layer parameters, hardware, and
-        `tf.executing_eagerly()` one implementation can be dramatically faster
-        (e.g. 50X) than another.
+            Depending on the inputs, layer parameters, hardware, and
+            `tf.executing_eagerly()` one implementation can be dramatically faster
+            (e.g. 50X) than another.
 
-        It is recommended to benchmark both in the setting of interest to pick
-        the most efficient one (in terms of speed and memory usage).
+            It is recommended to benchmark both in the setting of interest to pick
+            the most efficient one (in terms of speed and memory usage).
 
-        Following scenarios could benefit from setting `implementation=2`:
+            Following scenarios could benefit from setting `implementation=2`:
 
-        - eager execution;
-        - inference;
-        - running on CPU;
-        - large amount of RAM available;
-        - small models (few filters, small kernel);
-        - using `padding=same` (only possible with `implementation=2`).
+            - eager execution;
+            - inference;
+            - running on CPU;
+            - large amount of RAM available;
+            - small models (few filters, small kernel);
+            - using `padding=same` (only possible with `implementation=2`).
 
     # Input shape
-    3D tensor with shape: `(batch_size, steps, input_dim)`
+        3D tensor with shape: `(batch_size, steps, input_dim)`
 
     # Output shape
-    3D tensor with shape: `(batch_size, new_steps, filters)`
-    `steps` value might have changed due to padding or strides.
+        3D tensor with shape: `(batch_size, new_steps, filters)`
+        `steps` value might have changed due to padding or strides.
     """
 
     def __init__(
@@ -1197,71 +1217,71 @@ class QuantLocallyConnected2D(QuantizerBase, tf.keras.layers.LocallyConnected2D)
         ```
 
     # Arguments
-    filters: Integer, the dimensionality of the output space
-        (i.e. the number of output filters in the convolution).
-    kernel_size: An integer or tuple/list of 2 integers, specifying the
-        width and height of the 2D convolution window. Can be a single integer to
-        specify the same value for all spatial dimensions.
-    strides: An integer or tuple/list of 2 integers, specifying the strides of the
-        convolution along the width and height. Can be a single integer to specify
-        the same value for all spatial dimensions.
-    padding: Currently only support `"valid"` (case-insensitive).
-        `"same"` will be supported in future.
-    data_format: A string, one of `channels_last` (default) or `channels_first`.
-        The ordering of the dimensions in the inputs. `channels_last` corresponds to
-        inputs with shape `(batch, height, width, channels)` while `channels_first`
-        corresponds to inputs with shape `(batch, channels, height, width)`. It
-        defaults to the `image_data_format` value found in your Keras config file at
-        `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
-    activation: Activation function to use. If you don't specify anything,
-        no activation is applied (`a(x) = x`).
-    use_bias: Boolean, whether the layer uses a bias vector.
-    input_quantizer: Quantization function applied to the input of the layer.
-    kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
-    kernel_initializer: Initializer for the `kernel` weights matrix.
-    bias_initializer: Initializer for the bias vector.
-    kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
-    bias_regularizer: Regularizer function applied to the bias vector.
-    activity_regularizer: Regularizer function applied to
-        the output of the layer (its "activation").
-    kernel_constraint: Constraint function applied to the kernel matrix.
-    bias_constraint: Constraint function applied to the bias vector.
-    implementation: implementation mode, either `1` or `2`.
-        `1` loops over input spatial locations to perform the forward pass.
-        It is memory-efficient but performs a lot of (small) ops.
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number of output filters in the convolution).
+        kernel_size: An integer or tuple/list of 2 integers, specifying the
+            width and height of the 2D convolution window. Can be a single integer to
+            specify the same value for all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers, specifying the strides of the
+            convolution along the width and height. Can be a single integer to specify
+            the same value for all spatial dimensions.
+        padding: Currently only support `"valid"` (case-insensitive).
+            `"same"` will be supported in future.
+        data_format: A string, one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs. `channels_last` corresponds to
+            inputs with shape `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape `(batch, channels, height, width)`. It
+            defaults to the `image_data_format` value found in your Keras config file at
+            `~/.keras/keras.json`. If you never set it, then it will be "channels_last".
+        activation: Activation function to use. If you don't specify anything,
+            no activation is applied (`a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        input_quantizer: Quantization function applied to the input of the layer.
+        kernel_quantizer: Quantization function applied to the `kernel` weights matrix.
+        kernel_initializer: Initializer for the `kernel` weights matrix.
+        bias_initializer: Initializer for the bias vector.
+        kernel_regularizer: Regularizer function applied to the `kernel` weights matrix.
+        bias_regularizer: Regularizer function applied to the bias vector.
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+        kernel_constraint: Constraint function applied to the kernel matrix.
+        bias_constraint: Constraint function applied to the bias vector.
+        implementation: implementation mode, either `1` or `2`.
+            `1` loops over input spatial locations to perform the forward pass.
+            It is memory-efficient but performs a lot of (small) ops.
 
-        `2` stores layer weights in a dense but sparsely-populated 2D matrix
-        and implements the forward pass as a single matrix-multiply. It uses
-        a lot of RAM but performs few (large) ops.
+            `2` stores layer weights in a dense but sparsely-populated 2D matrix
+            and implements the forward pass as a single matrix-multiply. It uses
+            a lot of RAM but performs few (large) ops.
 
-        Depending on the inputs, layer parameters, hardware, and
-        `tf.executing_eagerly()` one implementation can be dramatically faster
-        (e.g. 50X) than another.
+            Depending on the inputs, layer parameters, hardware, and
+            `tf.executing_eagerly()` one implementation can be dramatically faster
+            (e.g. 50X) than another.
 
-        It is recommended to benchmark both in the setting of interest to pick
-        the most efficient one (in terms of speed and memory usage).
+            It is recommended to benchmark both in the setting of interest to pick
+            the most efficient one (in terms of speed and memory usage).
 
-        Following scenarios could benefit from setting `implementation=2`:
+            Following scenarios could benefit from setting `implementation=2`:
 
-        - eager execution;
-        - inference;
-        - running on CPU;
-        - large amount of RAM available;
-        - small models (few filters, small kernel);
-        - using `padding=same` (only possible with `implementation=2`).
+            - eager execution;
+            - inference;
+            - running on CPU;
+            - large amount of RAM available;
+            - small models (few filters, small kernel);
+            - using `padding=same` (only possible with `implementation=2`).
 
     # Input shape
-    4D tensor with shape:
-    `(samples, channels, rows, cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(samples, rows, cols, channels)` if data_format='channels_last'.
+        4D tensor with shape:
+        `(samples, channels, rows, cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(samples, rows, cols, channels)` if data_format='channels_last'.
 
     # Output shape
-    4D tensor with shape:
-    `(samples, filters, new_rows, new_cols)` if data_format='channels_first'
-    or 4D tensor with shape:
-    `(samples, new_rows, new_cols, filters)` if data_format='channels_last'.
-    `rows` and `cols` values might have changed due to padding.
+        4D tensor with shape:
+        `(samples, filters, new_rows, new_cols)` if data_format='channels_first'
+        or 4D tensor with shape:
+        `(samples, new_rows, new_cols, filters)` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
     """
 
     def __init__(

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -892,10 +892,10 @@ class QuantConv2DTranspose(QuantizerBase, tf.keras.layers.Conv2DTranspose):
         `rows` and `cols` values might have changed due to padding.
 
     # References
-    - [A guide to convolution arithmetic for deep
-      learning](https://arxiv.org/abs/1603.07285v1)
-    - [Deconvolutional
-      Networks](https://www.matthewzeiler.com/mattzeiler/deconvolutionalnetworks.pdf)
+        - [A guide to convolution arithmetic for deep
+            learning](https://arxiv.org/abs/1603.07285v1)
+        - [Deconvolutional
+            Networks](https://www.matthewzeiler.com/mattzeiler/deconvolutionalnetworks.pdf)
     """
 
     def __init__(

--- a/larq/math.py
+++ b/larq/math.py
@@ -17,10 +17,10 @@ def sign(x):
     return a binary value and will never be zero.
 
     # Arguments
-    `x`: Input Tensor
+        `x`: Input Tensor
 
     # Returns
-    A Tensor with same type as `x`.
+        A Tensor with same type as `x`.
     """
     return tf.sign(tf.sign(x) + 0.1)
 
@@ -36,9 +36,9 @@ def heaviside(x):
     \\]
 
     # Arguments
-    `x`: Input Tensor
+        `x`: Input Tensor
 
     # Returns
-    A Tensor with same type as `x`.
+        A Tensor with same type as `x`.
     """
     return tf.sign(tf.nn.relu(x))

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -26,9 +26,9 @@ class FlipRatio(tf.keras.metrics.Metric):
         ```
 
     # Arguments
-    name: Name of the metric.
-    values_dtype: Data type of the tensor for which to track changes.
-    dtype: Data type of the moving mean.
+        name: Name of the metric.
+        values_dtype: Data type of the tensor for which to track changes.
+        dtype: Data type of the moving mean.
     """
 
     def __init__(self, values_dtype="int8", name="flip_ratio", dtype=None):

--- a/larq/models.py
+++ b/larq/models.py
@@ -456,7 +456,7 @@ def summary(
         model: model instance.
         print_fn: Print function to use. Defaults to `print`. You can set it to a custom
             function in order to capture the string summary.
-        include_macs: whether or not to include the number of MAC-operations in the 
+        include_macs: whether or not to include the number of MAC-operations in the
             summary.
 
     # Raises

--- a/larq/models.py
+++ b/larq/models.py
@@ -423,7 +423,7 @@ class SummaryTable(AsciiTable):
 
 
 def summary(
-    model, print_fn: Callable[[str], Any] = print, include_macs: bool = True
+    model, print_fn: Callable[[str], Any] = None, include_macs: bool = True
 ) -> None:
     """Prints a string summary of the network.
 
@@ -466,6 +466,9 @@ def summary(
             "`model.build()` or calling `model.fit()` with some data, or specify an "
             "`input_shape` argument in the first layer(s) for automatic build."
         )
+
+    if not print_fn:
+        print_fn = print
 
     model_profile = ModelProfile(model)
     print_fn(

--- a/larq/models.py
+++ b/larq/models.py
@@ -423,7 +423,9 @@ class SummaryTable(AsciiTable):
 
 
 def summary(
-    model, print_fn: Callable[[str], Any] = None, include_macs: bool = True
+    model: tf.keras.models.Model,
+    print_fn: Callable[[str], Any] = None,
+    include_macs: bool = True,
 ) -> None:
     """Prints a string summary of the network.
 

--- a/larq/models.py
+++ b/larq/models.py
@@ -451,13 +451,14 @@ def summary(
     - ratio of MAC operations that is binarized and can be accelated with XNOR-gates.
 
     # Arguments
-    model: `tf.keras` model instance.
-    print_fn: Print function to use. Defaults to `print`. You can set it to a custom
-        function in order to capture the string summary.
-    include_macs: whether or not to include the number of MAC-operations in the summary.
+        model: model instance.
+        print_fn: Print function to use. Defaults to `print`. You can set it to a custom
+            function in order to capture the string summary.
+        include_macs: whether or not to include the number of MAC-operations in the 
+            summary.
 
     # Raises
-    ValueError: if called before the model is built.
+        ValueError: if called before the model is built.
     """
 
     if not model.built:

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -59,11 +59,12 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
     `default_optimizer == None`, the variable is not trained.
 
     # Arguments
-    predicate_optimizer_pairs: One or more `(pred, tf.keras.optimizers.Optimizer)` pairs,
-        where `pred`  takes one `tf.Variable` as argument and returns `True` if the
-        optimizer should be used for that variable, e.g. `pred(var) == True`.
-    default_optimizer: A `tf.keras.optimizers.Optimizer` to be applied to any variable
-        not claimed by any other optimizer. (Must be passed as keyword argument.)
+        predicate_optimizer_pairs: One or more `(pred, tf.keras.optimizers.Optimizer)`
+            pairs, where `pred`  takes one `tf.Variable` as argument and returns `True`
+            if the optimizer should be used for that variable, e.g. `pred(var) == True`.
+        default_optimizer: A `tf.keras.optimizers.Optimizer` to be applied to any
+            variable not claimed by any other optimizer. (Must be passed as keyword
+            argument.)
     """
 
     _HAS_AGGREGATE_GRAD = True
@@ -260,12 +261,12 @@ class Bop(tf.keras.optimizers.Optimizer):
         ```
 
     # Arguments
-    threshold: magnitude of average gradient signal required to flip a weight.
-    gamma: the adaptivity rate.
-    name: name of the optimizer.
+        threshold: magnitude of average gradient signal required to flip a weight.
+        gamma: the adaptivity rate.
+        name: name of the optimizer.
 
     # References
-    - [Latent Weights Do Not Exist: Rethinking Binarized Neural Network Optimization](https://papers.nips.cc/paper/8971-latent-weights-do-not-exist-rethinking-binarized-neural-network-optimization)
+        - [Latent Weights Do Not Exist: Rethinking Binarized Neural Network Optimization](https://papers.nips.cc/paper/8971-latent-weights-do-not-exist-rethinking-binarized-neural-network-optimization)
     """
 
     _HAS_AGGREGATE_GRAD = True
@@ -322,6 +323,6 @@ class Bop(tf.keras.optimizers.Optimizer):
         This is an example of a predictate that can be used by the `CaseOptimizer`.
 
         # Arguments
-        var: a `tf.Variable`.
+            var: a `tf.Variable`.
         """
         return getattr(var, "precision", 32) == 1

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -26,11 +26,11 @@ class QuantizedVariable(tf.Variable):
         """Creates an QuantizedVariable instance.
 
         # Arguments
-        variable: A floating-point resource variable to wrap.
-        quantizer: An optional quantizer to transform the floating-point
-            variable to a fake quantized variable.
-        precision: An optional integer defining the precision of the quantized
-            variable. If `None`, `quantizer.precision` is used.
+            variable: A floating-point resource variable to wrap.
+            quantizer: An optional quantizer to transform the floating-point
+                variable to a fake quantized variable.
+            precision: An optional integer defining the precision of the quantized
+                variable. If `None`, `quantizer.precision` is used.
         """
         if not resource_variable_ops.is_resource_variable(variable):
             raise ValueError(
@@ -68,14 +68,14 @@ class QuantizedVariable(tf.Variable):
         DistributedVariables and its subclasses to work properly.
 
         # Arguments
-        variable: A floating-point resource variable to wrap.
-        quantizer: An optional quantizer to transform the floating-point variable to a
-            fake quantized variable.
-        precision: An optional integer defining the precision of the quantized variable.
-            If `None`, `quantizer.precision` is used.
+            variable: A floating-point resource variable to wrap.
+            quantizer: An optional quantizer to transform the floating-point variable to
+                a fake quantized variable.
+            precision: An optional integer defining the precision of the quantized
+                variable. If `None`, `quantizer.precision` is used.
 
         # Returns
-        A QuantizedVariable that wraps the variable.
+            A QuantizedVariable that wraps the variable.
         """
         if not isinstance(variable, (DistributedVariable, AggregatingVariable)):  # type: ignore
             return cls(variable, quantizer, precision)
@@ -108,15 +108,16 @@ class QuantizedVariable(tf.Variable):
         AutoCastVariable. We return the original variable in that case.
 
         # Arguments
-        variable: A tf.Variable or op.
-        quantizer: An optional quantizer to transform the floating-point variable to a
-            fake quantized variable.
-        precision: An optional integer defining the precision of the quantized variable.
-            If `None`, `quantizer.precision` is used.
-        wrap: A boolean to define whether to wrap the variable in an QuantizedVariable.
+            variable: A tf.Variable or op.
+            quantizer: An optional quantizer to transform the floating-point variable to
+                a fake quantized variable.
+            precision: An optional integer defining the precision of the quantized
+                variable. If `None`, `quantizer.precision` is used.
+            wrap: A boolean to define whether to wrap the variable in a
+                `QuantizedVariable`.
 
         # Returns
-        An QuantizedVariable if wrap is True and variable is a resource variable.
+            A QuantizedVariable if wrap is True and variable is a resource variable.
         """
         if wrap and resource_variable_ops.is_resource_variable(variable):
             return QuantizedVariable.from_variable(variable, quantizer, precision)

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -194,10 +194,10 @@ class NoOp(BaseQuantizer):
         ```
 
     # Arguments
-    precision: Set the desired precision of the variable. This can be used to tag
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        precision: Set the desired precision of the variable. This can be used to tag
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
     """
     precision = None
 
@@ -239,14 +239,15 @@ class SteSign(BaseQuantizer):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        clip_value: Threshold for clipping gradients. If `None` gradients are not
+            clipped.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
 
     # References
-    - [Binarized Neural Networks: Training Deep Neural Networks with Weights and
-      Activations Constrained to +1 or -1](https://arxiv.org/abs/1602.02830)
+        - [Binarized Neural Networks: Training Deep Neural Networks with Weights and
+            Activations Constrained to +1 or -1](https://arxiv.org/abs/1602.02830)
     """
     precision = 1
 
@@ -285,14 +286,14 @@ class ApproxSign(BaseQuantizer):
     ```
 
     # Arguments
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
 
     # References
-    - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
-      Representational Capability and Advanced
-      Training Algorithm](https://arxiv.org/abs/1808.00278)
+        - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
+            Representational Capability and Advanced Training
+            Algorithm](https://arxiv.org/abs/1808.00278)
     """
     precision = 1
 
@@ -327,13 +328,14 @@ class SteHeaviside(BaseQuantizer):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        clip_value: Threshold for clipping gradients. If `None` gradients are not
+            clipped.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
 
     # Returns
-    AND Binarization function
+        AND Binarization function
     """
     precision = 1
 
@@ -371,16 +373,17 @@ class SwishSign(BaseQuantizer):
     quantizers.SwishSign
     ```
     # Arguments
-    beta: Larger values result in a closer approximation to the derivative of the sign.
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        beta: Larger values result in a closer approximation to the derivative of the
+            sign.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
 
     # Returns
-    SwishSign quantization function
+        SwishSign quantization function
 
     # References
-    - [BNN+: Improved Binary Network Training](https://arxiv.org/abs/1812.11800)
+        - [BNN+: Improved Binary Network Training](https://arxiv.org/abs/1812.11800)
     """
     precision = 1
 
@@ -409,15 +412,16 @@ class MagnitudeAwareSign(BaseQuantizer):
     ```
 
     # Arguments
-    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        clip_value: Threshold for clipping gradients. If `None` gradients are not
+            clipped.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
 
     # References
-    - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
-      Representational Capability and Advanced Training
-      Algorithm](https://arxiv.org/abs/1808.00278)
+        - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
+        Representational Capability and Advanced Training
+        Algorithm](https://arxiv.org/abs/1808.00278)
 
     """
     precision = 1
@@ -472,16 +476,17 @@ class SteTern(BaseQuantizer):
     ```
 
     # Arguments
-    threshold_value: The value for the threshold, \\(\Delta\\).
-    ternary_weight_networks: Boolean of whether to use the
-        Ternary Weight Networks threshold calculation.
-    clip_value: Threshold for clipping gradients. If `None` gradients are not clipped.
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        threshold_value: The value for the threshold, \\(\Delta\\).
+        ternary_weight_networks: Boolean of whether to use the
+            Ternary Weight Networks threshold calculation.
+        clip_value: Threshold for clipping gradients. If `None` gradients are not
+            clipped.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
 
     # References
-    - [Ternary Weight Networks](https://arxiv.org/abs/1605.04711)
+        - [Ternary Weight Networks](https://arxiv.org/abs/1605.04711)
     """
 
     precision = 2
@@ -529,7 +534,8 @@ class DoReFa(BaseQuantizer):
     \end{cases}
     \\]
 
-    where \\(n = 2^{\text{k_bit}} - 1\\). The number of bits, k_bit, needs to be passed as an argument.
+    where \\(n = 2^{\text{k_bit}} - 1\\). The number of bits, k_bit, needs to be passed
+    as an argument.
     The gradient is estimated using the Straight-Through Estimator
     (essentially the binarization is replaced by a clipped identity on the
     backward pass).
@@ -543,17 +549,17 @@ class DoReFa(BaseQuantizer):
     ```
 
     # Arguments
-    k_bit: number of bits for the quantization.
-    metrics: An array of metrics to add to the layer. If `None` the metrics set in
-        `larq.context.metrics_scope` are used. Currently only the `flip_ratio` metric is
-        available.
+        k_bit: number of bits for the quantization.
+        metrics: An array of metrics to add to the layer. If `None` the metrics set in
+            `larq.context.metrics_scope` are used. Currently only the `flip_ratio`
+            metric is available.
 
     # Returns
-    Quantization function
+        Quantization function
 
     # References
-    - [DoReFa-Net: Training Low Bitwidth Convolutional Neural Networks
-      with Low Bitwidth Gradients](https://arxiv.org/abs/1606.06160)
+        - [DoReFa-Net: Training Low Bitwidth Convolutional Neural Networks with Low
+            Bitwidth Gradients](https://arxiv.org/abs/1606.06160)
     """
     precision = None
 
@@ -615,10 +621,10 @@ def get_kernel_quantizer(identifier):
     """Returns a quantizer from identifier and adds default kernel quantizer metrics.
 
     # Arguments
-    identifier: Function or string
+        identifier: Function or string
 
     # Returns
-    `Quantizer` or `None`
+        `Quantizer` or `None`
     """
     quantizer = get(identifier)
     if isinstance(quantizer, BaseQuantizer) and not quantizer._custom_metrics:

--- a/larq/utils.py
+++ b/larq/utils.py
@@ -51,7 +51,7 @@ def set_precision(precision: int = 32):
     """A decorator to set the precision of a quantizer function
 
     # Arguments
-    precision: An integer defining the precision of the output.
+        precision: An integer defining the precision of the output.
     """
 
     def decorator(function):


### PR DESCRIPTION
This adds indentations to docstrings so that [keras-autodoc](https://github.com/keras-team/keras-autodoc) understands sections with lists of arguments, input shapes, output shapes, returns, etc. See larq/docs#68.

Before:

```
# Arguments:
arg_name: this is the description.
```

After:

```
# Arguments:
    arg_name: this is the description.
```

We'll probably need to do a minor release of Larq once we do this, and then bump the version that larq/docs uses to that version. 