### PR TITLE
Fix case optimizer when used with distributed mixed precision loss scaling

### DIFF
--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -139,6 +139,10 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             if var.name in self.var_opt_mapping:
                 grad_var_lists[self.var_opt_mapping[var.name]].append((grad, var))
 
+        with tf.init_scope():
+            for optimizer, opt_grads_and_vars in zip(self.optimizers, grad_var_lists):
+                optimizer._create_slots([v for (_, v) in grads_and_vars])
+
         return tf.distribute.get_replica_context().merge_call(
             self._apply_gradients, args=(grad_var_lists, name), kwargs=kwargs
         )

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -139,10 +139,17 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             if var.name in self.var_opt_mapping:
                 grad_var_lists[self.var_opt_mapping[var.name]].append((grad, var))
 
+        return tf.distribute.get_replica_context().merge_call(
+            self._apply_gradients, args=(grad_var_lists, name), kwargs=kwargs
+        )
+
+    def _apply_gradients(self, distribution, grad_var_lists, name, **kwargs):
         # Apply gradients to each optimizer
         with tf.name_scope(self._name):
             train_ops = [
-                optimizer.apply_gradients(opt_grads_and_vars, **kwargs)
+                distribution.extended.call_for_each_replica(
+                    optimizer.apply_gradients, args=(opt_grads_and_vars,), kwargs=kwargs
+                )
                 for optimizer, opt_grads_and_vars in zip(
                     self.optimizers, grad_var_lists
                 )


### PR DESCRIPTION
This fixes some issues that can occur when using the `CaseOptimizer` in distributed training with the mixed precision `LossScaleOptimizer`.

The failure on master can be reproduced using:
```python
import tensorflow as tf
from tensorflow.python.keras import testing_utils
from tensorflow.python.distribute.strategy_combinations import set_virtual_cpus_to_at_least

import larq as lq
from larq import testing_utils as lq_testing_utils

set_virtual_cpus_to_at_least(3)  # Simulate distributed training on CPU only machine

(x_train, y_train), _ = testing_utils.get_test_data(
    train_samples=1000, test_samples=0, input_shape=(10,), num_classes=2
)
y_train = tf.keras.utils.to_categorical(y_train)


with tf.distribute.MirroredStrategy(["/cpu:1", "/cpu:2"]).scope():
    model = lq_testing_utils.get_small_bnn_model(
        x_train.shape[1], 20, y_train.shape[1], trainable_bn=True
    )

    opt = lq.optimizers.CaseOptimizer(
        (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
        default_optimizer=tf.keras.optimizers.Adam(0.01),
    )
    opt = tf.keras.mixed_precision.experimental.LossScaleOptimizer(opt, "dynamic")
    model.compile(loss="categorical_crossentropy", optimizer=opt, metrics=["acc"])

    model.fit(x_train, y_train, epochs=2, batch_size=16, verbose=0)
```

Adding a unittest for this is tricky since calling `set_virtual_cpus_to_at_least` needs proper cleanup of the TensorFlow test session.

Closes #396