### PR TITLE
Correctly compute one-padding shape to prevent recreating conv_op

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -10,11 +10,20 @@ from larq.quantizers import Quantizer
 log = logging.getLogger(__name__)
 
 
-def _compute_padding(stride, dilation_rate, input_size, filter_size):
+def _compute_padded_size(stride, dilation_rate, input_size, filter_size):
+    if input_size is None:
+        return None
     effective_filter_size = (filter_size - 1) * dilation_rate + 1
     output_size = (input_size + stride - 1) // stride
-    total_padding = (output_size - 1) * stride + effective_filter_size - input_size
-    total_padding = tf.math.maximum(total_padding, 0)
+    padded_size = (output_size - 1) * stride + effective_filter_size
+    if tf.is_tensor(input_size):
+        return tf.math.maximum(padded_size, input_size)
+    return max(padded_size, input_size)
+
+
+def _compute_padding(stride, dilation_rate, input_size, filter_size):
+    padded_size = _compute_padded_size(stride, dilation_rate, input_size, filter_size)
+    total_padding = padded_size - input_size
     padding = total_padding // 2
     return padding, padding + (total_padding % 2)
 
@@ -127,9 +136,12 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
         )
 
     def _get_padding_same_shape(self, input_shape):
+        spatial_input_shape = self._get_spatial_shape(input_shape)
         spatial_shape = [
-            (size + stride - 1) // stride if size is not None else None
-            for size, stride in zip(self._get_spatial_shape(input_shape), self.strides)
+            _compute_padded_size(stride, dilation, size, filter_size)
+            for size, stride, dilation, filter_size in zip(
+                spatial_input_shape, self.strides, self.dilation_rate, self.kernel_size,
+            )
         ]
         if self.data_format == "channels_last":
             return tf.TensorShape([input_shape[0], *spatial_shape, input_shape[-1]])

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -203,8 +203,11 @@ class TestLayers:
         ref_layer = layer_cls(*args, padding="same", **kwargs)
         spy = mocker.spy(tf, "pad")
         layer = layer_cls(*args, padding="same", pad_values=1.0, **kwargs)
+        layer.build(inputs.shape)
+        conv_op = getattr(layer, "_convolution_op", None)
         assert layer(inputs).shape == ref_layer(inputs).shape
         spy.assert_called_once_with(mocker.ANY, mocker.ANY, constant_values=1.0)
+        assert conv_op == getattr(layer, "_convolution_op", None)
 
     @pytest.mark.parametrize(
         "layer_cls",


### PR DESCRIPTION
#461 introduced a bug which broke the computation of the padded output shape with one-padding. This resulted in convolution ops being recreated after the layer has been built. This PR fixes it by correctly computing the padded shape so that convolutional ops are not recreated after the layer has been built.

I noticed this bug when trying to debug @jneeven multi-GPU issues with Quantizer that call `self.add_update` and `one-padding`.