### PR TITLE
Fix metric typo

### DIFF
--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -36,12 +36,6 @@ class FlipRatio(tf.keras.metrics.Metric):
         self.built = False
         self.values_dtype = tf.as_dtype(values_dtype)
 
-    def __call__(self, inputs, **kwargs):
-        if not self.built:
-            with tf.name_scope(self.name), tf.init_scope():
-                self.build(inputs.shape)
-        return super().__call__(inputs, **kwargs)
-
     def build(self, input_shape):
         self._previous_values = self.add_weight(
             "previous_values",
@@ -67,7 +61,8 @@ class FlipRatio(tf.keras.metrics.Metric):
         values = tf.cast(values, self.values_dtype)
 
         if not self.built:
-            self.build(values.shape)
+            with tf.name_scope(self.name), tf.init_scope():
+                self.build(values.shape)
 
         unchanged_values = tf.math.count_nonzero(
             tf.equal(self._previous_values, values)

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -64,10 +64,11 @@ class FlipRatio(tf.keras.metrics.Metric):
         self.built = True
 
     def update_state(self, values, sample_weight=None):
+        values = tf.cast(values, self.values_dtype)
+
         if not self.built:
             self.build(values.shape)
 
-        values = tf.cast(values, self.values_dtype)
         unchanged_values = tf.math.count_nonzero(
             tf.equal(self._previous_values, values)
         )

--- a/larq/metrics.py
+++ b/larq/metrics.py
@@ -65,7 +65,7 @@ class FlipRatio(tf.keras.metrics.Metric):
 
     def update_state(self, values, sample_weight=None):
         if not self.built:
-            self._build(values.shape)
+            self.build(values.shape)
 
         values = tf.cast(values, self.values_dtype)
         unchanged_values = tf.math.count_nonzero(

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -45,6 +45,28 @@ def test_metric(eager_mode):
     assert 1.5 / 2 == mcv.result().numpy()
 
 
+def test_metric_implicit_build(eager_mode):
+    mcv = metrics.FlipRatio()
+
+    mcv.update_state(np.array([1, 1]))
+    assert all([1, 1] == mcv._previous_values.numpy())
+    assert 0 == mcv.total.numpy()
+    assert 1 == mcv.count.numpy()
+    assert 0 == mcv.result().numpy()
+
+    mcv.update_state(np.array([2, 2]))
+    assert all([2, 2] == mcv._previous_values.numpy())
+    assert 1 == mcv.total.numpy()
+    assert 2 == mcv.count.numpy()
+    assert 1 == mcv.result().numpy()
+
+    mcv.update_state(np.array([1, 2]))
+    assert all([1, 2] == mcv._previous_values.numpy())
+    assert 1.5 == mcv.total.numpy()
+    assert 3 == mcv.count.numpy()
+    assert 1.5 / 2 == mcv.result().numpy()
+
+
 def test_metric_wrong_shape(eager_mode):
     mcv = metrics.FlipRatio()
     mcv.build((3,))


### PR DESCRIPTION
This corrects a very minor typo that didn't show up in the tests because we were explicitly building. However, this did make the [docstring example](https://github.com/larq/larq/blob/04ea8153ef10484dab68873cfe3ea37db5615ca4/larq/metrics.py#L21) fail.