### PR TITLE
Add support for TensorFlow 2.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.7
       - name: Install project dependencies
         run: |
-          pip install tensorflow==2.1.0
+          pip install tensorflow-cpu==2.2.0
           pip install -e .[test]
       - name: Run Flake8
         run: flake8

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: 3.6
       - name: Install dependencies
         run: |
-          pip install tensorflow-cpu==2.1.0
+          pip install tensorflow-cpu==2.2.0
           pip install -e .[test]
       - name: Generate coverage report
         run: pytest . -n auto --cov=larq --cov-report=xml --cov-config=.coveragerc

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0]
+        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0, 2.3.0rc0]
         python-version: [3.7]
         include:
           - tf-version: 2.2.0

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -3,16 +3,16 @@
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.python.distribute.values import DistributedVariable
+from tensorflow.python.distribute.values import DistributedVariable  # type: ignore
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import resource_variable_ops
 
 from larq import context
 from larq.quantizers import Quantizer
 
-try:
-    from tensorflow.python.types.core import Tensor as TensorType
-    from tensorflow.python.distribute.ps_values import AggregatingVariable
+try:  # pragma: no cover
+    from tensorflow.python.types.core import Tensor as TensorType  # type: ignore
+    from tensorflow.python.distribute.ps_values import AggregatingVariable  # type: ignore
 except ModuleNotFoundError:
     TensorType = object
     from tensorflow.python.distribute.values import AggregatingVariable
@@ -366,5 +366,5 @@ tf.register_tensor_conversion_function(
 )
 try:
     ops.register_dense_tensor_like_type(QuantizedVariable)
-except AttributeError:
+except AttributeError:  # pragma: no cover
     pass

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -3,18 +3,22 @@
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.python.distribute.values import (  # type: ignore
-    AggregatingVariable,
-    DistributedVariable,
-)
+from tensorflow.python.distribute.values import DistributedVariable
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import resource_variable_ops
 
 from larq import context
 from larq.quantizers import Quantizer
 
+try:
+    from tensorflow.python.types.core import Tensor as TensorType
+    from tensorflow.python.distribute.ps_values import AggregatingVariable
+except ModuleNotFoundError:
+    TensorType = object
+    from tensorflow.python.distribute.values import AggregatingVariable
 
-class QuantizedVariable(tf.Variable):
+
+class QuantizedVariable(tf.Variable, TensorType):
     """A Variable that can be quantized in the forward pass in applicable contexts."""
 
     def __init__(
@@ -360,4 +364,7 @@ QuantizedVariable._OverloadAllOperators()
 tf.register_tensor_conversion_function(
     QuantizedVariable, QuantizedVariable._dense_var_to_tensor
 )
-ops.register_dense_tensor_like_type(QuantizedVariable)
+try:
+    ops.register_dense_tensor_like_type(QuantizedVariable)
+except AttributeError:
+    pass

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.python.distribute.values import DistributedVariable  # type: ignore
+from tensorflow.python.distribute.values import DistributedVariable
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import resource_variable_ops
 
@@ -81,7 +81,7 @@ class QuantizedVariable(tf.Variable, TensorType):
         # Returns
             A QuantizedVariable that wraps the variable.
         """
-        if not isinstance(variable, (DistributedVariable, AggregatingVariable)):  # type: ignore
+        if not isinstance(variable, (DistributedVariable, AggregatingVariable)):
             return cls(variable, quantizer, precision)
 
         class QuantizedDistributedVariable(cls, variable.__class__):

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -18,7 +18,7 @@ def test_inheritance(distribute_scope):
     quantized_variable = QuantizedVariable.from_variable(variable)
     assert isinstance(quantized_variable, QuantizedVariable)
     assert isinstance(quantized_variable, tf.Variable)
-    assert isinstance(quantized_variable, DistributedVariable) is distribute_scope  # type: ignore
+    assert isinstance(quantized_variable, DistributedVariable) is distribute_scope
 
 
 @pytest.mark.usefixtures("eager_and_graph_mode", "distribute_scope")


### PR DESCRIPTION
This integrates changes of https://github.com/tensorflow/tensorflow/commit/8d31fb4b765260a6d0bcaf825ca68766b5b798ee#diff-8db8dd75efb914430be51c632dfa452e and https://github.com/tensorflow/tensorflow/commit/c5caa29b5e6d10079020673a0dbd0035214df94d

~~Since these changes haven't been released yet I didn't add any CI checks that test against tf-nightly~~ I added TF 2.3.0rc0 to the CI test matrix.