### PR TITLE
Apply Python Black formatting to docstring examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,21 @@ To build a QNN, Larq introduces the concept of [quantized layers](https://docs.l
 You can define a simple binarized fully-connected Keras model using the [Straight-Through Estimator](https://docs.larq.dev/larq/api/quantizers/#ste_sign) the following way:
 
 ```python
-model = tf.keras.models.Sequential([
-    tf.keras.layers.Flatten(),
-    larq.layers.QuantDense(512,
-                           kernel_quantizer="ste_sign",
-                           kernel_constraint="weight_clip"),
-    larq.layers.QuantDense(10,
-                           input_quantizer="ste_sign",
-                           kernel_quantizer="ste_sign",
-                           kernel_constraint="weight_clip",
-                           activation="softmax")])
+model = tf.keras.models.Sequential(
+    [
+        tf.keras.layers.Flatten(),
+        larq.layers.QuantDense(
+            512, kernel_quantizer="ste_sign", kernel_constraint="weight_clip"
+        ),
+        larq.layers.QuantDense(
+            10,
+            input_quantizer="ste_sign",
+            kernel_quantizer="ste_sign",
+            kernel_constraint="weight_clip",
+            activation="softmax",
+        ),
+    ]
+)
 ```
 
 This layer can be used inside a [Keras model](https://www.tensorflow.org/guide/keras/overview#sequential_model) or with a [custom training loop](https://www.tensorflow.org/guide/keras/train_and_evaluate#part_ii_writing_your_own_training_evaluation_loops_from_scratch).

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -263,10 +263,7 @@ class Bop(tf.keras.optimizers.Optimizer):
         layer = lq.layers.QuantDense(16, kernel_quantizer=no_op_quantizer)
 
         optimizer = lq.optimizers.CaseOptimizer(
-            (
-                lq.optimizers.Bop.is_binary_variable,
-                lq.optimizers.Bop(),
-            ),
+            (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
             default_optimizer=tf.keras.optimizers.Adam(0.01),  # for FP weights
         )
         ```

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -186,8 +186,7 @@ class NoOp(BaseQuantizer):
     !!! example
         ```python
         layer = lq.layers.QuantDense(
-            16,
-            kernel_quantizer=lq.quantizers.NoOpQuantizer(precision=1),
+            16, kernel_quantizer=lq.quantizers.NoOpQuantizer(precision=1),
         )
         layer.build((32,))
         assert layer.kernel.precision == 1


### PR DESCRIPTION
This will make our docs more consistent by having all Python code formatted using [Python Black](https://github.com/psf/black), like class and method signatures currently already are.