### PR TITLE
Cleanup tests

### DIFF
--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -73,3 +73,8 @@ def quantized(request):
     """pytest fixture for running test quantized and non-quantized"""
     with lq_context.quantized_scope(request.param):
         yield request.param
+
+
+@pytest.fixture(params=["channels_last", "channels_first"])
+def data_format(request):
+    return request.param

--- a/larq/conftest_test.py
+++ b/larq/conftest_test.py
@@ -1,3 +1,4 @@
+import pytest
 import tensorflow as tf
 
 from larq import context
@@ -11,11 +12,13 @@ def test_eager_and_graph_mode_fixture(eager_and_graph_mode):
         assert tf.compat.v1.get_default_session() is not None
 
 
-def test_eager_mode_fixture(eager_mode):
+@pytest.mark.usefixtures("eager_mode")
+def test_eager_mode_fixture():
     assert tf.executing_eagerly()
 
 
-def test_graph_mode_fixture(graph_mode):
+@pytest.mark.usefixtures("graph_mode")
+def test_graph_mode_fixture():
     assert not tf.executing_eagerly()
     assert tf.compat.v1.get_default_session() is not None
 

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -184,7 +184,6 @@ class TestLayers:
             (lq.layers.QuantDepthwiseConv2D, 4),
         ],
     )
-    @pytest.mark.parametrize("data_format", ["channels_last", "channels_first"])
     @pytest.mark.parametrize("dilation", [True, False])
     def test_non_zero_padding_layers(
         self, mocker, layer_cls, input_dim, data_format, dilation
@@ -220,7 +219,6 @@ class TestLayers:
             lq.layers.QuantDepthwiseConv2D,
         ],
     )
-    @pytest.mark.parametrize("data_format", ["channels_last", "channels_first"])
     @pytest.mark.parametrize("static", [True, False])
     def test_non_zero_padding_shapes(self, layer_cls, data_format, static):
         layer = layer_cls(

--- a/larq/metrics_test.py
+++ b/larq/metrics_test.py
@@ -19,7 +19,8 @@ def test_config():
     assert mcv2.values_dtype == tf.int16
 
 
-def test_metric(eager_mode):
+@pytest.mark.usefixtures("eager_mode")
+def test_metric():
     mcv = metrics.FlipRatio()
     mcv.build((2,))
     assert 0 == mcv.result().numpy()
@@ -45,7 +46,8 @@ def test_metric(eager_mode):
     assert 1.5 / 2 == mcv.result().numpy()
 
 
-def test_metric_implicit_build(eager_mode):
+@pytest.mark.usefixtures("eager_mode")
+def test_metric_implicit_build():
     mcv = metrics.FlipRatio()
 
     mcv.update_state(np.array([1, 1]))
@@ -67,14 +69,16 @@ def test_metric_implicit_build(eager_mode):
     assert 1.5 / 2 == mcv.result().numpy()
 
 
-def test_metric_wrong_shape(eager_mode):
+@pytest.mark.usefixtures("eager_mode")
+def test_metric_wrong_shape():
     mcv = metrics.FlipRatio()
     mcv.build((3,))
     with pytest.raises((ValueError, tf.errors.InvalidArgumentError)):
         mcv.update_state(np.array([1, 1]))
 
 
-def test_metric_in_graph_mode(graph_mode):
+@pytest.mark.usefixtures("graph_mode")
+def test_metric_in_graph_mode():
     mcv = metrics.FlipRatio()
     mcv.build((2,))
 

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -169,7 +169,8 @@ class TestCaseOptimizer:
                 checked_weights += 1
         assert checked_weights == len(opt_weights)
 
-    def test_checkpoint(self, eager_mode, tmp_path):
+    @pytest.mark.usefixtures("eager_mode")
+    def test_checkpoint(self, tmp_path):
         # Build and run a simple model.
         var = tf.Variable([2.0])
         opt = tf.keras.optimizers.SGD(1.0, momentum=1.0)

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -21,7 +21,8 @@ def test_inheritance(distribute_scope):
     assert isinstance(quantized_variable, DistributedVariable) is distribute_scope  # type: ignore
 
 
-def test_read(eager_and_graph_mode, distribute_scope):
+@pytest.mark.usefixtures("eager_and_graph_mode", "distribute_scope")
+def test_read():
     x = QuantizedVariable.from_variable(get_var(3.5), quantizer=lambda x: 2 * x)
     evaluate(x.initializer)
 
@@ -37,7 +38,8 @@ def test_read(eager_and_graph_mode, distribute_scope):
         assert evaluate(tf.identity(x)) == 7
 
 
-def test_sparse_reads(eager_and_graph_mode):
+@pytest.mark.usefixtures("eager_and_graph_mode")
+def test_sparse_reads():
     x = QuantizedVariable.from_variable(get_var([1.0, 2.0]), quantizer=lambda x: 2 * x)
     evaluate(x.initializer)
 
@@ -48,7 +50,8 @@ def test_sparse_reads(eager_and_graph_mode):
         assert evaluate(x.gather_nd([0])) == 2
 
 
-def test_read_nested_scopes(eager_and_graph_mode, distribute_scope):
+@pytest.mark.usefixtures("eager_and_graph_mode", "distribute_scope")
+def test_read_nested_scopes():
     x = QuantizedVariable.from_variable(get_var(3.5), quantizer=lambda x: 2 * x)
     evaluate(x.initializer)
     with context.quantized_scope(True):
@@ -58,7 +61,8 @@ def test_read_nested_scopes(eager_and_graph_mode, distribute_scope):
         assert evaluate(x.read_value()) == 7
 
 
-def test_method_delegations(eager_and_graph_mode, distribute_scope):
+@pytest.mark.usefixtures("eager_and_graph_mode")
+def test_method_delegations(distribute_scope):
     x = QuantizedVariable.from_variable(get_var(3.5), quantizer=lambda x: 2 * x)
     with context.quantized_scope(True):
         evaluate(x.initializer)
@@ -90,7 +94,8 @@ def test_method_delegations(eager_and_graph_mode, distribute_scope):
         assert x.get_shape() == ()
 
 
-def test_scatter_method_delegations(eager_and_graph_mode):
+@pytest.mark.usefixtures("eager_and_graph_mode")
+def test_scatter_method_delegations():
     x = QuantizedVariable.from_variable(get_var([3.5, 4]), quantizer=lambda x: 2 * x)
     evaluate(x.initializer)
     with context.quantized_scope(True):
@@ -118,7 +123,8 @@ def test_scatter_method_delegations(eager_and_graph_mode):
         )
 
 
-def test_overloads(eager_and_graph_mode, quantized, distribute_scope):
+@pytest.mark.usefixtures("eager_and_graph_mode", "distribute_scope")
+def test_overloads(quantized):
     if quantized:
         x = QuantizedVariable.from_variable(get_var(3.5), quantizer=lambda x: 2 * x)
     else:
@@ -153,7 +159,8 @@ def test_overloads(eager_and_graph_mode, quantized, distribute_scope):
     assert_almost_equal(7, evaluate(abs(x)))
 
 
-def test_tensor_equality(quantized, eager_mode):
+@pytest.mark.usefixtures("eager_mode")
+def test_tensor_equality(quantized):
     if quantized:
         x = QuantizedVariable.from_variable(
             get_var([3.5, 4.0, 4.5]), quantizer=lambda x: 2 * x
@@ -167,7 +174,8 @@ def test_tensor_equality(quantized, eager_mode):
         assert_array_equal(x != [7.0, 8.0, 10.0], [False, False, True])
 
 
-def test_assign(eager_and_graph_mode, quantized, distribute_scope):
+@pytest.mark.usefixtures("eager_and_graph_mode", "distribute_scope")
+def test_assign(quantized):
     x = QuantizedVariable.from_variable(
         get_var(0.0, tf.float64), quantizer=lambda x: 2 * x
     )
@@ -218,7 +226,8 @@ def test_assign(eager_and_graph_mode, quantized, distribute_scope):
     assert_almost_equal(evaluate(tf.compat.v1.assign_sub(x, latent_value)), value)
 
 
-def test_checkpoint(tmp_path, eager_and_graph_mode):
+@pytest.mark.usefixtures("eager_and_graph_mode")
+def test_checkpoint(tmp_path):
     x = QuantizedVariable.from_variable(get_var(0.0), quantizer=lambda x: 2 * x)
     evaluate(x.initializer)
     evaluate(x.assign(123.0))
@@ -233,7 +242,8 @@ def test_checkpoint(tmp_path, eager_and_graph_mode):
         assert evaluate(x) == 123.0 * 2
 
 
-def test_invalid_wrapped_usage(distribute_scope):
+@pytest.mark.usefixtures("distribute_scope")
+def test_invalid_wrapped_usage():
     with pytest.raises(ValueError, match="`variable` must be of type"):
         QuantizedVariable.from_variable(tf.constant([1.0]))
     with pytest.raises(ValueError, match="`quantizer` must be `callable` or `None`"):
@@ -242,7 +252,8 @@ def test_invalid_wrapped_usage(distribute_scope):
         QuantizedVariable.from_variable(get_var([1.0]), precision=1.0)  # type: ignore
 
 
-def test_repr(snapshot, eager_and_graph_mode):
+@pytest.mark.usefixtures("eager_and_graph_mode")
+def test_repr(snapshot):
     x = get_var(0.0, name="x")
 
     class Quantizer:
@@ -258,8 +269,9 @@ def test_repr(snapshot, eager_and_graph_mode):
     snapshot.assert_match(repr(QuantizedVariable.from_variable(x, precision=1)))
 
 
+@pytest.mark.usefixtures("eager_mode")
 @pytest.mark.parametrize("should_quantize", [True, False])
-def test_optimizer(eager_mode, should_quantize):
+def test_optimizer(should_quantize):
     x = QuantizedVariable.from_variable(get_var(1.0), quantizer=lambda x: -x)
     opt = tf.keras.optimizers.SGD(1.0)
 


### PR DESCRIPTION
This PR simplifies some of our testing code and switches to using `@pytest.mark.usefixtures` in cases where function arguments are never used. I think this makes it easier to read and understand what these arguments do. I also moved the data format parameterization into a shared fixture.