### PR TITLE
Run distribution strategy tests with multiple virtual CPUs

### DIFF
--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -1,9 +1,16 @@
 import pytest
 import tensorflow as tf
 from packaging import version
+from tensorflow.python.distribute import strategy_combinations
 from tensorflow.python.eager import context
 
 from larq import context as lq_context
+
+if version.parse(tf.__version__) >= version.parse("1.15"):
+    strategy_combinations.set_virtual_cpus_to_at_least(3)
+    distributed_devices = ["/cpu:1", "/cpu:2"]
+else:
+    distributed_devices = ["/cpu:0"]
 
 
 @pytest.fixture
@@ -62,7 +69,7 @@ def keras_should_run_eagerly(request):
 @pytest.fixture(params=[False, True])
 def distribute_scope(request):
     if request.param is True:
-        with tf.distribute.MirroredStrategy(["cpu:0"]).scope():
+        with tf.distribute.MirroredStrategy(distributed_devices).scope():
             yield request.param
     else:
         yield request.param

--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -9,7 +9,7 @@ from larq import context as lq_context
 if version.parse(tf.__version__) >= version.parse("1.15"):
     strategy_combinations.set_virtual_cpus_to_at_least(3)
     distributed_devices = ["/cpu:1", "/cpu:2"]
-else:
+else:  # pragma: no cover
     distributed_devices = ["/cpu:0"]
 
 

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -214,6 +214,7 @@ class TestBopOptimizer:
             target=0,
         )
 
+    @pytest.mark.usefixtures("distribute_scope")
     def test_mixed_precision(self):
         opt = lq.optimizers.CaseOptimizer(
             (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -85,9 +85,10 @@ def test_method_delegations(distribute_scope):
             # These attributes are not supported for DistributedVariables
             assert x.constraint is None
             assert x.initializer == x.latent_variable.initializer
-        assert evaluate(x.assign(4)) == 8
-        assert evaluate(x.assign_add(1)) == 10
-        assert evaluate(x.assign_sub(1.5)) == 7
+            # DistributedVariables.assign doesn't correctly return quantized variables
+            assert evaluate(x.assign(4)) == 8
+            assert evaluate(x.assign_add(1)) == 10
+            assert evaluate(x.assign_sub(1.5)) == 7
         assert x.name == x.latent_variable.name
         assert x.device == x.latent_variable.device
         assert x.shape == ()
@@ -174,8 +175,8 @@ def test_tensor_equality(quantized):
         assert_array_equal(x != [7.0, 8.0, 10.0], [False, False, True])
 
 
-@pytest.mark.usefixtures("eager_and_graph_mode", "distribute_scope")
-def test_assign(quantized):
+@pytest.mark.usefixtures("eager_and_graph_mode")
+def test_assign(quantized, distribute_scope):
     x = QuantizedVariable.from_variable(
         get_var(0.0, tf.float64), quantizer=lambda x: 2 * x
     )
@@ -184,23 +185,33 @@ def test_assign(quantized):
     latent_value = 3.14
     value = latent_value * 2 if quantized else latent_value
 
-    # Assign float32 values
-    lv = tf.constant(latent_value, dtype=tf.float64)
-    assert_almost_equal(evaluate(x.assign(lv)), value)
-    assert_almost_equal(evaluate(x.assign_add(lv)), value * 2)
-    assert_almost_equal(evaluate(x.assign_sub(lv)), value)
+    # Assign doesn't correctly return a quantized variable in distribution scope
+    if not distribute_scope or not quantized:
+        # Assign float32 values
+        lv = tf.constant(latent_value, dtype=tf.float64)
+        assert_almost_equal(evaluate(x.assign(lv)), value)
+        assert_almost_equal(evaluate(x.assign_add(lv)), value * 2)
+        assert_almost_equal(evaluate(x.assign_sub(lv)), value)
 
-    # Assign Python floats
-    assert_almost_equal(evaluate(x.assign(0.0)), 0.0)
-    assert_almost_equal(evaluate(x.assign(latent_value)), value)
-    assert_almost_equal(evaluate(x.assign_add(latent_value)), value * 2)
-    assert_almost_equal(evaluate(x.assign_sub(latent_value)), value)
+        # Assign Python floats
+        assert_almost_equal(evaluate(x.assign(0.0)), 0.0)
+        assert_almost_equal(evaluate(x.assign(latent_value)), value)
+        assert_almost_equal(evaluate(x.assign_add(latent_value)), value * 2)
+        assert_almost_equal(evaluate(x.assign_sub(latent_value)), value)
 
-    # Assign multiple times
-    assign = x.assign(0.0)
-    assert_almost_equal(evaluate(assign), 0.0)
-    assert_almost_equal(evaluate(assign.assign(latent_value)), value)
-    if version.parse(tf.__version__) >= version.parse("2.2"):
+        # Use the tf.assign functions instead of the var.assign methods.
+        assert_almost_equal(evaluate(tf.compat.v1.assign(x, 0.0)), 0.0)
+        assert_almost_equal(evaluate(tf.compat.v1.assign(x, latent_value)), value)
+        assert_almost_equal(
+            evaluate(tf.compat.v1.assign_add(x, latent_value)), value * 2
+        )
+        assert_almost_equal(evaluate(tf.compat.v1.assign_sub(x, latent_value)), value)
+
+        # Assign multiple times
+    if not distribute_scope:
+        assign = x.assign(0.0)
+        assert_almost_equal(evaluate(assign), 0.0)
+        assert_almost_equal(evaluate(assign.assign(latent_value)), value)
         assert_almost_equal(
             evaluate(x.assign_add(latent_value).assign_add(latent_value)), value * 3
         )
@@ -218,12 +229,6 @@ def test_assign(quantized):
     assert_almost_equal(evaluate(x), 2 * value)
     assert evaluate(x.assign_sub(latent_value, read_value=False)) is None
     assert_almost_equal(evaluate(x), value)
-
-    # Use the tf.assign functions instead of the var.assign methods.
-    assert_almost_equal(evaluate(tf.compat.v1.assign(x, 0.0)), 0.0)
-    assert_almost_equal(evaluate(tf.compat.v1.assign(x, latent_value)), value)
-    assert_almost_equal(evaluate(tf.compat.v1.assign_add(x, latent_value)), value * 2)
-    assert_almost_equal(evaluate(tf.compat.v1.assign_sub(x, latent_value)), value)
 
 
 @pytest.mark.usefixtures("eager_and_graph_mode")

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -208,7 +208,7 @@ def test_assign(quantized, distribute_scope):
         assert_almost_equal(evaluate(tf.compat.v1.assign_sub(x, latent_value)), value)
 
         # Assign multiple times
-    if not distribute_scope:
+    if not distribute_scope and version.parse(tf.__version__) >= version.parse("2.2"):
         assign = x.assign(0.0)
         assert_almost_equal(evaluate(assign), 0.0)
         assert_almost_equal(evaluate(assign.assign(latent_value)), value)

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -85,7 +85,7 @@ def test_method_delegations(distribute_scope):
             # These attributes are not supported for DistributedVariables
             assert x.constraint is None
             assert x.initializer == x.latent_variable.initializer
-        
+
         def apply_and_read(x, fn, args):
             evaluate(fn(*args))
             return evaluate(x)

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -85,10 +85,14 @@ def test_method_delegations(distribute_scope):
             # These attributes are not supported for DistributedVariables
             assert x.constraint is None
             assert x.initializer == x.latent_variable.initializer
-            # DistributedVariables.assign doesn't correctly return quantized variables
-            assert evaluate(x.assign(4)) == 8
-            assert evaluate(x.assign_add(1)) == 10
-            assert evaluate(x.assign_sub(1.5)) == 7
+        
+        def apply_and_read(x, fn, args):
+            evaluate(fn(*args))
+            return evaluate(x)
+
+        assert apply_and_read(x, x.assign, [4]) == 8
+        assert apply_and_read(x, x.assign_add, [1]) == 10
+        assert apply_and_read(x, x.assign_sub, [1.5]) == 7
         assert x.name == x.latent_variable.name
         assert x.device == x.latent_variable.device
         assert x.shape == ()


### PR DESCRIPTION
This PR changes the distribution strategy fixture to use two virtual CPUs. This will correctly simulate distributed training which allows us to catch bugs like #485 in our unittests and allows for easy local debugging of multi-GPU issues.

I had to ignore a few known failure cases due to some underlying TensorFlow issues of quantized variables, since the new fixture correctly simulates multi-GPU environments on CI.