### PR TITLE
Fix saving in SavedModel format

### DIFF
--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -324,6 +324,13 @@ class QuantizedVariable(tf.Variable, TensorType):
         # models with normal variables, and vice versa.
         return self.latent_variable._gather_saveables_for_checkpoint()
 
+    def _map_resources(self):
+        # By delegating this method to the wrapped variable, SavedModel with
+        # QuantizedVariables are identical to SavedModel with normal variables.
+        obj_map, resource_map = self.latent_variable._map_resources()
+        obj_map[self] = obj_map[self.latent_variable]
+        return obj_map, resource_map
+
     # TODO: Maybe encode the fact the variable is an QuantizedVariable in to_proto().
     def to_proto(self, *args, **kwargs):
         return self.latent_variable.to_proto(*args, **kwargs)
@@ -332,7 +339,7 @@ class QuantizedVariable(tf.Variable, TensorType):
         return self.latent_variable.from_proto(*args, **kwargs)
 
     # Delegate the private attributes _handle_name and _initializer_op to
-    # self._variable. SavedModel sets these attributes when loading a model. For
+    # self.latent_variable. SavedModel sets these attributes when loading a model. For
     # example, it sets _handle_name here:
     # https://github.com/tensorflow/tensorflow/blob/db26bd574fa95b5bdd53c08463dd19407cc0297e/tensorflow/python/keras/saving/saved_model/load.py#L211
     # We need to expose these attributes on AutoCastVariable as well for

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -342,19 +342,19 @@ class QuantizedVariable(tf.Variable, TensorType):
     # For more info see https://github.com/tensorflow/tensorflow/commit/1fcda57f37c2ac854cabf1c3462eb14e39d36c60
     @property
     def _handle_name(self):
-        return self._variable._handle_name
+        return self.latent_variable._handle_name
 
     @_handle_name.setter
     def _handle_name(self, handle_name):
-        self._variable._handle_name = handle_name
+        self.latent_variable._handle_name = handle_name
 
     @property
     def _initializer_op(self):
-        return self._variable._initializer_op
+        return self.latent_variable._initializer_op
 
     @_initializer_op.setter
     def _initializer_op(self, initializer_op):
-        self._variable._initializer_op = initializer_op
+        self.latent_variable._initializer_op = initializer_op
 
     def _as_graph_element(self):
         return self._quantize(self.latent_variable._as_graph_element())

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -305,10 +305,6 @@ def test_optimizer(should_quantize):
 @pytest.mark.skipif(
     version.parse(tf.__version__) < version.parse("2"), reason="Requires TensorFlow 2",
 )
-@pytest.mark.skipif(
-    version.parse(tf.__version__) == version.parse("2.3.0rc0"),
-    reason="Currently broken on 2.3.0rc0.",
-)
 def test_saved_model(tmp_path):
     model_path = str(tmp_path / "model")
     x = np.random.normal(size=(4, 32))

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -305,6 +305,10 @@ def test_optimizer(should_quantize):
 @pytest.mark.skipif(
     version.parse(tf.__version__) < version.parse("2"), reason="Requires TensorFlow 2",
 )
+@pytest.mark.skipif(
+    version.parse(tf.__version__) == version.parse("2.3.0rc0"),
+    reason="Currently broken on 2.3.0rc0.",
+)
 def test_saved_model(tmp_path):
     model_path = str(tmp_path / "model")
     x = np.random.normal(size=(4, 32))

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -309,6 +309,11 @@ def test_saved_model(tmp_path):
     model_path = str(tmp_path / "model")
     x = np.random.normal(size=(4, 32))
     model = testing_utils.get_small_bnn_model(x.shape[1], 16, 10)
+    weights = model.get_weights()
     model.save(model_path, save_format="tf")
     reloaded_model = tf.keras.models.load_model(model_path)
+    reloaded_weights = reloaded_model.get_weights()
     assert_almost_equal(reloaded_model.predict(x), model.predict(x))
+    assert len(reloaded_weights) == len(weights)
+    for reloaded_weight, weight in zip(reloaded_weights, weights):
+        assert_almost_equal(reloaded_weight, weight)

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -1,10 +1,11 @@
+import numpy as np
 import pytest
 import tensorflow as tf
 from numpy.testing import assert_almost_equal, assert_array_equal
 from packaging import version
 from tensorflow.python.distribute.values import DistributedVariable
 
-from larq import context
+from larq import context, testing_utils
 from larq.quantized_variable import QuantizedVariable
 from larq.testing_utils import evaluate
 
@@ -299,3 +300,12 @@ def test_optimizer(should_quantize):
             assert evaluate(x) == -2.0
     else:
         assert evaluate(x) == 0.0
+
+
+def test_saved_model(tmp_path):
+    model_path = str(tmp_path / "model")
+    x = np.random.normal(size=(4, 32))
+    model = testing_utils.get_small_bnn_model(x.shape[1], 16, 10)
+    model.save(model_path, save_format="tf")
+    reloaded_model = tf.keras.models.load_model(model_path)
+    assert_almost_equal(reloaded_model.predict(x), model.predict(x))

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -302,6 +302,9 @@ def test_optimizer(should_quantize):
         assert evaluate(x) == 0.0
 
 
+@pytest.mark.skipif(
+    version.parse(tf.__version__) < version.parse("2"), reason="Requires TensorFlow 2",
+)
 def test_saved_model(tmp_path):
     model_path = str(tmp_path / "model")
     x = np.random.normal(size=(4, 32))


### PR DESCRIPTION
This PR fixes saving of larq models in the TensorFlow `SavedModel` format.