### PR TITLE
Always upload coverage on CI to reduce flaky code coverage reports

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.14.0, 1.15.2, 2.0.1, 2.1.0, 2.3.0rc0]
+        tf-version: [1.14.0, 1.15.3, 2.0.2, 2.1.1, 2.2.0, 2.3.0rc0]
         python-version: [3.7]
         include:
+          - tf-version: 2.2.0
+            python-version: 3.6
           - tf-version: 2.2.0
             python-version: 3.8
 
@@ -25,23 +27,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install tensorflow==${{matrix.tf-version}}
+          pip install tensorflow-cpu==${{matrix.tf-version}} || pip install tensorflow==${{matrix.tf-version}}
           pip install -e .[test]
       - name: Test with pytest
-        run: pytest . -n auto
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2.0.1
-        with:
-          python-version: 3.6
-      - name: Install dependencies
-        run: |
-          pip install tensorflow-cpu==2.2.0
-          pip install -e .[test]
-      - name: Generate coverage report
         run: pytest . -n auto --cov=larq --cov-report=xml --cov-config=.coveragerc
       - name: Upload coverage to Codecov
-        run: curl -s https://codecov.io/bash | bash -s -- -f ./coverage.xml -F unittests
+        run: bash <(curl -s https://codecov.io/bash) -f ./coverage.xml -F unittests

--- a/larq/conftest.py
+++ b/larq/conftest.py
@@ -9,7 +9,7 @@ from larq import context as lq_context
 if version.parse(tf.__version__) >= version.parse("1.15"):
     strategy_combinations.set_virtual_cpus_to_at_least(3)
     distributed_devices = ["/cpu:1", "/cpu:2"]
-else:  # pragma: no cover
+else:
     distributed_devices = ["/cpu:0"]
 
 

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -10,7 +10,7 @@ from tensorflow.python.ops import resource_variable_ops
 from larq import context
 from larq.quantizers import Quantizer
 
-try:  # pragma: no cover
+try:
     from tensorflow.python.types.core import Tensor as TensorType  # type: ignore
     from tensorflow.python.distribute.ps_values import AggregatingVariable  # type: ignore
 except ModuleNotFoundError:
@@ -366,5 +366,5 @@ tf.register_tensor_conversion_function(
 )
 try:
     ops.register_dense_tensor_like_type(QuantizedVariable)
-except AttributeError:  # pragma: no cover
+except AttributeError:
     pass


### PR DESCRIPTION
Since we have special handling for different TensorFlow version Codecov sometimes reported wrong results (see e.g.  #514). This PR changes our CI to always compute coverage and let Codecov handle the merging automatically.