### PR TITLE
Run linting using Python 3.8 on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2.1.2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install project dependencies
         run: |
           pip install tensorflow-cpu==2.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,4 @@ output = .pytype
 keep_going = True
 # Don't check use of imported modules, because we have no type-stubs for TF.
 strict_import = True
-python_version = 3.7
+python_version = 3.8


### PR DESCRIPTION
This PR switches linting on CI to use Python 3.8 since `pytype` requires matching Python versions to properly run type checking.