### PR TITLE
Raise exception when causal padding is used with pad_values != 0

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -103,9 +103,10 @@ class QuantizerBaseConv(tf.keras.layers.Layer):
     def __init__(self, *args, pad_values=0.0, **kwargs):
         self.pad_values = pad_values
         super().__init__(*args, **kwargs)
-        self._is_native_padding = self.padding != "same" or (
-            not tf.is_tensor(self.pad_values) and self.pad_values == 0.0
-        )
+        is_zero_padding = not tf.is_tensor(self.pad_values) and self.pad_values == 0.0
+        self._is_native_padding = self.padding != "same" or is_zero_padding
+        if self.padding == "causal" and not is_zero_padding:
+            raise ValueError("Causal padding with `pad_values != 0` is not supported.")
 
     def _get_spatial_padding_same(self, shape):
         return [

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -276,6 +276,10 @@ class TestLayerWarns:
         )
         assert caplog.records == []
 
+    def test_conv1d_non_zero_padding_raises(self):
+        with pytest.raises(ValueError, match=r".*pad_values.*"):
+            lq.layers.QuantConv1D(24, 3, padding="causal", pad_values=1.0)
+
 
 @pytest.mark.parametrize(
     "quant_layer,layer",


### PR DESCRIPTION
Following up on #574, we currently do not support causal padding with `pad_values != 0`
This PR will raise and exception since otherwise the current code would fall back to `pad_values=0`.