### PR TITLE
Fix indentation of DoReFa warning

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -545,9 +545,9 @@ class DoReFa(BaseQuantizer):
     \end{cases}\\]
 
     !!! warning
-       While the DoReFa paper describes how to do quantization for both weights and
-       activations, this implementation is only valid for activations, and this
-       quantizer should therefore not be used as a kernel quantizer.
+        While the DoReFa paper describes how to do quantization for both weights and
+        activations, this implementation is only valid for activations, and this
+        quantizer should therefore not be used as a kernel quantizer.
 
     ```plot-activation
     quantizers.DoReFa


### PR DESCRIPTION
This fixes the indentation of the warning message so it renders correctly on the website.