### PR TITLE
Relax importlib-metadata dependency constraint for older Python < 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "numpy >= 1.15.4, < 2.0",
         "terminaltables>=3.1.0",
         "dataclasses ; python_version<'3.7'",
-        "importlib-metadata ~= 2.0 ; python_version<'3.8'",
+        "importlib-metadata >= 2.0, < 4.0 ; python_version<'3.8'",
     ],
     extras_require={
         "tensorflow": ["tensorflow>=1.14.0"],


### PR DESCRIPTION
`importlib-metadata@3` was released yesterday which dropped support for Python 3.5. We can easily relax the version requirements to reduce potential conflicts in userspace.