### PR TITLE
Call super().build() in Quantizers.build()

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -157,6 +157,7 @@ class BaseQuantizer(tf.keras.layers.Layer):
     def build(self, input_shape):
         if self._custom_metrics and "flip_ratio" in self._custom_metrics:
             self.flip_ratio = lq_metrics.FlipRatio(name=f"flip_ratio/{self.name}")
+        super().build(input_shape)
 
     def call(self, inputs):
         if hasattr(self, "flip_ratio"):


### PR DESCRIPTION
This ensures that Layer.built is correctly set.
Closes #620