### PR TITLE
Favour lq.quantizers.NoOp over NoOpQuantizer

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -5,14 +5,14 @@ import tensorflow as tf
 
 from larq import context, quantizers, utils
 from larq.quantized_variable import QuantizedVariable
-from larq.quantizers import NoOpQuantizer, Quantizer
+from larq.quantizers import NoOp, Quantizer
 
 log = logging.getLogger(__name__)
 
 
 def _is_binary(quantizer):
     return getattr(quantizer, "precision", None) == 1 and not isinstance(
-        quantizer, NoOpQuantizer
+        quantizer, NoOp
     )
 
 

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -201,7 +201,7 @@ class NoOp(_BaseQuantizer):
     !!! example
         ```python
         layer = lq.layers.QuantDense(
-            16, kernel_quantizer=lq.quantizers.NoOpQuantizer(precision=1),
+            16, kernel_quantizer=lq.quantizers.NoOp(precision=1),
         )
         layer.build((32,))
         assert layer.kernel.precision == 1


### PR DESCRIPTION
The name `NoOpQuantizer` has been deprecated since #468