### PR TITLE
Rename Quantizer type to prevent conflict with base class

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 
 from larq import context, quantizers, utils
 from larq.quantized_variable import QuantizedVariable
-from larq.quantizers import NoOpQuantizer, Quantizer
+from larq.quantizers import NoOpQuantizer, QuantizerType
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class BaseLayer(tf.keras.layers.Layer):
             "input_quantizer": quantizers.serialize(self.input_quantizer),
         }
 
-    def _get_quantizer(self, name) -> Optional[Quantizer]:
+    def _get_quantizer(self, name) -> Optional[QuantizerType]:
         """Get quantizer for given kernel name"""
         return None
 
@@ -93,7 +93,7 @@ class QuantizerBase(BaseLayer):
                 "may result in starved weights (where the gradient is always zero)."
             )
 
-    def _get_quantizer(self, name: str) -> Optional[Quantizer]:
+    def _get_quantizer(self, name: str) -> Optional[QuantizerType]:
         return self.kernel_quantizer if name == "kernel" else None
 
     def get_config(self):
@@ -189,7 +189,7 @@ class QuantizerDepthwiseBase(BaseLayer):
     def __init__(
         self,
         *args,
-        depthwise_quantizer: Optional[Quantizer] = None,
+        depthwise_quantizer: Optional[QuantizerType] = None,
         **kwargs,
     ):
         self.depthwise_quantizer = quantizers.get_kernel_quantizer(depthwise_quantizer)
@@ -201,7 +201,7 @@ class QuantizerDepthwiseBase(BaseLayer):
                 "may result in starved weights (where the gradient is always zero)."
             )
 
-    def _get_quantizer(self, name: str) -> Optional[Quantizer]:
+    def _get_quantizer(self, name: str) -> Optional[QuantizerType]:
         return self.depthwise_quantizer if name == "depthwise_kernel" else None
 
     def get_config(self):
@@ -222,8 +222,8 @@ class QuantizerSeparableBase(BaseLayer):
     def __init__(
         self,
         *args,
-        depthwise_quantizer: Optional[Quantizer] = None,
-        pointwise_quantizer: Optional[Quantizer] = None,
+        depthwise_quantizer: Optional[QuantizerType] = None,
+        pointwise_quantizer: Optional[QuantizerType] = None,
         **kwargs,
     ):
         self.depthwise_quantizer = quantizers.get_kernel_quantizer(depthwise_quantizer)
@@ -241,7 +241,7 @@ class QuantizerSeparableBase(BaseLayer):
                 "may result in starved weights (where the gradient is always zero)."
             )
 
-    def _get_quantizer(self, name: str) -> Optional[Quantizer]:
+    def _get_quantizer(self, name: str) -> Optional[QuantizerType]:
         if name == "depthwise_kernel":
             return self.depthwise_quantizer
         if name == "pointwise_kernel":

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -7,7 +7,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import resource_variable_ops
 
 from larq import context
-from larq.quantizers import Quantizer
+from larq.quantizers import QuantizerType
 
 # pytype: disable=import-error
 try:
@@ -28,7 +28,7 @@ class QuantizedVariable(tf.Variable, TensorType):
     def __init__(
         self,
         variable: tf.Variable,
-        quantizer: Optional[Quantizer] = None,
+        quantizer: Optional[QuantizerType] = None,
         precision: Optional[int] = None,
         op: Optional[tf.Operation] = UNSPECIFIED,
     ):
@@ -66,7 +66,7 @@ class QuantizedVariable(tf.Variable, TensorType):
     def from_variable(
         cls,
         variable: tf.Variable,
-        quantizer: Optional[Quantizer] = None,
+        quantizer: Optional[QuantizerType] = None,
         precision: Optional[int] = None,
         op: Optional[tf.Operation] = UNSPECIFIED,
     ):

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -606,7 +606,7 @@ class DoReFa(_BaseQuantizer):
 DoReFaQuantizer = DoReFa
 
 
-Quantizer = Union[tf.keras.layers.Layer, Callable[[tf.Tensor], tf.Tensor]]
+QuantizerType = Union[Quantizer, Callable[[tf.Tensor], tf.Tensor]]
 
 
 def serialize(quantizer: tf.keras.layers.Layer):


### PR DESCRIPTION
This type definition overwrote the base class introduced in #623 which leads to problems when trying to use `lq.quantizers.Quantizer`.

This PR renames renames the `Quantizer` type to  `QuantizerType` to prevent this conflict. Alternatively we could think about a `lq.types` module. Let's see if pytype is now happy about this.