### PR TITLE
Initialise CaseOptimizer.iterations which is required in TF 2.3+

### DIFF
--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -121,6 +121,10 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             weights.extend(optimizer.weights)
         return weights
 
+    @tf.keras.optimizers.Optimizer.iterations.setter
+    def iterations(self, variable):
+        raise NotImplementedError("CaseOptimzer does not support setting iterations.")
+
     def apply_gradients(self, grads_and_vars, name: Optional[str] = None, **kwargs):
         """Apply gradients to variables for each optimizer.
 
@@ -141,6 +145,8 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
                 grad_var_lists[self.var_opt_mapping[var.name]].append((grad, var))
 
         with tf.init_scope():
+            _ = self.iterations
+            # This is only necessary in TF 2.0 and older, but doesn't hurt on newer versions
             for optimizer, opt_grads_and_vars in zip(self.optimizers, grad_var_lists):
                 optimizer._create_slots([v for (_, v) in grads_and_vars])
 


### PR DESCRIPTION
This PR correctly initialises `CaseOptimizer.iterations` which is required since TF 2.3+ due to https://github.com/tensorflow/tensorflow/commit/7152155517fbda482b4bffe66ddf56fd06b6aa04 which prevented reloading in TF 2.3+ when using multi-GPU and mixed precision training.
For now I also disabled the possibility to set `CaseOptimizer.iterations` manually which can lead to problems when forwarded to the different cases (If they share the same variable they would increment it multiple times during each step).

This is not the entirely correct behaviour since changes in `CaseOptimizer.iterations` won't be reflected in the different cases. As far as I can tell, in our current use this only happens when [mixed precision drops a batch due to the loss scale](https://github.com/tensorflow/tensorflow/blob/2f7e5cfb94e67a60eb6f393d283f9f91d20e76f1/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py#L734-L738) or iterations are incremented manually.

I am happy to fix this in a future PR by syncing them before each update step, but for now this prevents the current issue.

~~This PR forwards `optimizer.iterations` in `CaseOptimizer` which prevents reloading problems in TF 2.4 when using multi-GPU and mixed precision training.~~

~~This solution is also used in the [LossScaleOptimizer](https://github.com/tensorflow/tensorflow/blob/2f7e5cfb94e67a60eb6f393d283f9f91d20e76f1/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py#L816-L822) itself.~~

~~In our case this is not entirely correct since this could lead to iterations of different optimizers to become out of sync. E.g. in cases [where mixed precision drops a batch due to the loss scale](https://github.com/tensorflow/tensorflow/blob/2f7e5cfb94e67a60eb6f393d283f9f91d20e76f1/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py#L734-L738) or iterations are incremented manually. However I don't think this will cause issues in practice and properly fixing this would either mean that we need to introduce a dedicated iteration variable in the case optimizer and manually increment it or we need to find a way to keep the iterations in sync between the optimizers.
I am happy to look into this if necessary, but I don't think this is worth it for now. What do you think?~~