### PR TITLE
Pass the layer's dtype to the nested quantizers

### DIFF
--- a/larq/layers_base.py
+++ b/larq/layers_base.py
@@ -52,10 +52,10 @@ class BaseLayer(tf.keras.layers.Layer):
             return super().call(inputs)
 
     def get_config(self):
-        return {
-            **super().get_config(),
-            "input_quantizer": quantizers.serialize(self.input_quantizer),
-        }
+        quantizer_config = quantizers.serialize(self.input_quantizer)
+        if quantizer_config is not None:
+            quantizer_config["config"]["dtype"] = self.dtype
+        return {**super().get_config(), "input_quantizer": quantizer_config}
 
     def _get_quantizer(self, name) -> Optional[QuantizerType]:
         """Get quantizer for given kernel name"""
@@ -97,9 +97,12 @@ class QuantizerBase(BaseLayer):
         return self.kernel_quantizer if name == "kernel" else None
 
     def get_config(self):
+        quantizer_config = quantizers.serialize(self.kernel_quantizer)
+        if quantizer_config is not None:
+            quantizer_config["config"]["dtype"] = self.dtype
         return {
             **super().get_config(),
-            "kernel_quantizer": quantizers.serialize(self.kernel_quantizer),
+            "kernel_quantizer": quantizer_config,
         }
 
 
@@ -205,9 +208,12 @@ class QuantizerDepthwiseBase(BaseLayer):
         return self.depthwise_quantizer if name == "depthwise_kernel" else None
 
     def get_config(self):
+        quantizer_config = quantizers.serialize(self.depthwise_quantizer)
+        if quantizer_config is not None:
+            quantizer_config["config"]["dtype"] = self.dtype
         return {
             **super().get_config(),
-            "depthwise_quantizer": quantizers.serialize(self.depthwise_quantizer),
+            "depthwise_quantizer": quantizer_config,
         }
 
 
@@ -249,8 +255,14 @@ class QuantizerSeparableBase(BaseLayer):
         return None
 
     def get_config(self):
+        depthwise_quantizer_config = quantizers.serialize(self.depthwise_quantizer)
+        if depthwise_quantizer_config is not None:
+            depthwise_quantizer_config["config"]["dtype"] = self.dtype
+        pointwise_quantizer_config = quantizers.serialize(self.pointwise_quantizer)
+        if pointwise_quantizer_config is not None:
+            pointwise_quantizer_config["config"]["dtype"] = self.dtype
         return {
             **super().get_config(),
-            "depthwise_quantizer": quantizers.serialize(self.depthwise_quantizer),
-            "pointwise_quantizer": quantizers.serialize(self.pointwise_quantizer),
+            "depthwise_quantizer": depthwise_quantizer_config,
+            "pointwise_quantizer": pointwise_quantizer_config,
         }


### PR DESCRIPTION

This PR propagates the layer's data-type to the nested quantizers. This is important in case the Keras mixed-precision policy is used, as described [here](https://github.com/tensorflow/community/blob/master/rfcs/20200929-keras-mixed-precision.md#nesting-layers). For example, the following conversion would result in a `TypeError` before this PR, but works after these changes:

```python
import tensorflow as tf
import larq as lq

tf.keras.mixed_precision.set_global_policy("mixed_float16")

img = tf.keras.layers.Input(shape=(224, 224, 3))
x = lq.layers.QuantConv2D(3, (3, 3), input_quantizer=lq.quantizers.SteSign(clip_value=1.25))(img)
model = tf.keras.Model(img, x)

model = tf.keras.models.clone_model(
    model,
    clone_function=lambda layer: layer.__class__.from_config(
        {**layer.get_config(), "dtype": "float32"}
    )
)
```