### PR TITLE
[callbacks.py] switch to python3 super() call

### DIFF
--- a/larq/callbacks.py
+++ b/larq/callbacks.py
@@ -41,7 +41,7 @@ class HyperparameterScheduler(keras.callbacks.Callback):
         verbose: int = 0,
         log_name: Optional[str] = None,
     ):
-        super(HyperparameterScheduler, self).__init__()
+        super().__init__()
         self.optimizer = optimizer
         self.schedule = schedule
         self.hyperparameter = hyperparameter


### PR DESCRIPTION
Dear larq developers,

This (very small) PR updates the only remaining python2 super call to the shorter python3 syntax. This is in agreement with your required python versions and improves the code-style consistency.

Best, Peter