### PR TITLE
Add DoReFa Weight Quantizer

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -665,7 +665,7 @@ class DoReFaKernel(DoReFa):
         # So when all elements are zero, nothing is normed. This is achieved by
         # dividing by 1.
         dividend = tf.math.reduce_max(tf.math.abs(limited))
-        dividend = tf.where(dividend == 0., tf.ones_like(dividend), dividend)
+        dividend = tf.where(dividend == 0.0, tf.ones_like(dividend), dividend)
 
         # Need to stop the gradient here. Otherwise, for the maximum element,
         # which gives the dividend, normed is limited/limited (for this one
@@ -680,11 +680,11 @@ class DoReFaKernel(DoReFa):
 
         # Norm and scale from value range [-1,1] to [0,1]
         normed = limited / dividend
-        normed = (normed / 2.) + 0.5
+        normed = (normed / 2.0) + 0.5
 
         # Quantize and scale back to [-1,1] range
         quantized = super().call(normed)
-        quantized = (2. * quantized) - 1.
+        quantized = (2.0 * quantized) - 1.0
 
         return quantized
 

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -673,7 +673,7 @@ class DoReFaKernel(DoReFa):
         #one does the simplification y = x/x = 1. But TF does NOT do this
         #simplification when computing the gradient for the
         #normed = limited/dividend operation. As a result, this gradient becomes
-        #complex, because during the computation, "dividend" is not just a
+        #complicated, because during the computation, "dividend" is not just a
         #constant, but depends on "limited" instead. Here, tf.stop_gradient
         #is used to mark "dividend" as a constant explicitly.
         dividend = tf.stop_gradient(dividend)

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -624,7 +624,8 @@ class DoReFa(_BaseQuantizer):
         self.precision = k_bit
 
         if mode not in ("activations", "weights"):
-            raise ValueError(f"Invalid DoReFa quantizer mode {mode}.")
+            raise ValueError(f"Invalid DoReFa quantizer mode {mode}. "
+                             f"Valid values are 'activations' and 'weights'.")
         self.mode = mode
 
         super().__init__(**kwargs)
@@ -664,7 +665,8 @@ class DoReFa(_BaseQuantizer):
         elif self.mode == "weights":
             inputs = self.weight_preprocess(inputs)
         else:
-            raise ValueError(f"Invalid DoReFa quantizer mode {self.mode}.")
+            raise ValueError(f"Invalid DoReFa quantizer mode {self.mode}. "
+                             f"Valid values are 'activations' and 'weights'.")
 
         @tf.custom_gradient
         def _k_bit_with_identity_grad(x):

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -682,10 +682,7 @@ class DoReFaKernel(DoReFa):
         normed = (normed / 2.0) + 0.5
 
         # Quantize and scale back to [-1,1] range
-        quantized = super().call(normed)
-        quantized = (2.0 * quantized) - 1.0
-
-        return quantized
+        return 2.0 * super().call(normed) - 1.0
 
 
 # `DoReFa` used to be called `DoReFaQuantizer`; this alias is for

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -676,7 +676,7 @@ class DoReFaKernel(DoReFa):
         # If the dividend used for the norm operation is 0, all elements of
         # the weight tensor are 0 and divide_no_nan returns 0 for all weights.
         # So if all elements of the weight tensor are zero, nothing is normed.
-        normed = tf.math.divide_no_nan(limited, dividend) / 2.0 + 0.5
+        normed = tf.math.divide_no_nan(limited, 2.0 * dividend) + 0.5
 
         # Quantize and scale back to [-1,1] range
         return 2.0 * super().call(normed) - 1.0

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -614,7 +614,7 @@ class DoReFaKernel(DoReFa):
     with a gradient, which is contineously differentiable itself.
 
     \\[
-    w_{lim}(w) = tanh(w)
+    w_{lim}(w) = \tanh(w)
     \\]
 
     Furthermore, the weights of each layer are normed, such that the weight with
@@ -622,27 +622,27 @@ class DoReFaKernel(DoReFa):
     quantizable value. That way, the full quantizable numeric range is utilized.
 
     \\[
-    w_{norm}(w) = \frac{w}{max(|w|)}
+    w_{norm}(w) = \frac{w}{\max(|w|)}
     \\]
 
     The formulas can be found in the paper in section 2.3. Please note, that
-    the paper refers to weights being quantized on a numeric range of [-1,1], while
-    activations are quantized on the numeric range [0,1]. `DoReFa` defines the
+    the paper refers to weights being quantized on a numeric range of [-1, 1], while
+    activations are quantized on the numeric range [0, 1]. `DoReFa` defines the
     quantization function quantizek() from the paper with the correct numeric
-    range of [0,1], which is why the range needs to be adapted before applying
+    range of [0, 1], which is why the range needs to be adapted before applying
     `DoReFa` after applying the preprocessing (limit and norm).
     The hard limiting inside `DoReFa` becomes ineffective, because its input
     is already limited by the hyperbolic tangent. The full quantization
     function including the adaption of numeric ranges is
 
     \\[
-    q(w) = 2quantize_{k}(\frac{w_{norm}\left(w_{lim}\left(w\right)\right)}{2} + \frac{1}{2}) - 1
+    q(w) = 2 \, quantize_{k}(\frac{w_{norm}\left(w_{lim}\left(w\right)\right)}{2} + \frac{1}{2}) - 1
     \\]
 
     !!! warning
-        This quantizer works for weights on the range [-1,1], which matches the
+        This quantizer works for weights on the range [-1, 1], which matches the
         default setting of `constraints.weight_clip`. Do not use this quantizer
-        with a different constraint *clip_value* than the default one.
+        with a different constraint `clip_value` than the default one.
 
     ```plot-activation
     quantizers.DoReFaKernel

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -56,7 +56,7 @@ __all__ = [
     "ApproxSign",
     "DoReFa",
     "DoReFaQuantizer",
-    "DoReFaWeight",
+    "DoReFaKernel",
     "MagnitudeAwareSign",
     "NoOp",
     "NoOpQuantizer",
@@ -662,7 +662,7 @@ class DoReFaKernel(DoReFa):
         
         #Divider for max-value norm.
         #If all elements are 0., we would get a div by zero.
-        #So when all elements are zero, nothing is normed. This achieved by
+        #So when all elements are zero, nothing is normed. This is achieved by
         #dividing by 1.
         dividend = tf.reduce_max(tf.abs(limited))
         dividend = tf.where(dividend == 0., tf.ones_like(dividend), dividend)

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -678,8 +678,7 @@ class DoReFaKernel(DoReFa):
         dividend = tf.stop_gradient(dividend)
 
         # Norm and scale from value range [-1,1] to [0,1]
-        normed = limited / dividend
-        normed = (normed / 2.0) + 0.5
+        normed = limited / dividend / 2.0 + 0.5
 
         # Quantize and scale back to [-1,1] range
         return 2.0 * super().call(normed) - 1.0

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -667,6 +667,17 @@ class DoReFaKernel(DoReFa):
         dividend = tf.reduce_max(tf.abs(limited))
         dividend = tf.where(dividend == 0., tf.ones_like(dividend), dividend)
         
+        #Need to stop the gradient here. Otherwise, for the maximum element,
+        #which gives the dividend, normed is limited/limited (for this one
+        #maximum digit). The derivative of y = x/x, dy/dx is just zero, when
+        #one does the simplification y = x/x = 1. But TF does NOT do this
+        #simplification when computing the gradient for the
+        #normed = limited/dividend operation. As a result, this gradient becomes
+        #complex, because during the computation, "dividend" is not just a
+        #constant, but depends on "limited" instead. Here, tf.stop_gradient
+        #is used to mark "dividend" as a constant explicitly.
+        dividend = tf.stop_gradient(dividend)
+        
         #Norm and scale from value range [-1,1] to [0,1]
         normed = limited / dividend
         normed = (normed / 2.) + 0.5

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -601,7 +601,7 @@ class DoReFa(_BaseQuantizer):
 
     # Arguments
         k_bit: number of bits for the quantization.
-        mode: "activations" for clipping inputs on [0, 1] range or "weights" for
+        mode: `"activations"` for clipping inputs on [0, 1] range or `"weights"` for
             soft-clipping and norming weights on [-1, 1] range before applying
             quantization.
         metrics: An array of metrics to add to the layer. If `None` the metrics set in
@@ -626,7 +626,7 @@ class DoReFa(_BaseQuantizer):
         if mode not in ("activations", "weights"):
             raise ValueError(
                 f"Invalid DoReFa quantizer mode {mode}. "
-                f"Valid values are 'activations' and 'weights'."
+                "Valid values are 'activations' and 'weights'."
             )
         self.mode = mode
 
@@ -655,9 +655,7 @@ class DoReFa(_BaseQuantizer):
         # If the dividend used for the norm operation is 0, all elements of
         # the weight tensor are 0 and divide_no_nan returns 0 for all weights.
         # So if all elements of the weight tensor are zero, nothing is normed.
-        normed = tf.math.divide_no_nan(limited, 2.0 * dividend) + 0.5
-
-        return normed
+        return tf.math.divide_no_nan(limited, 2.0 * dividend) + 0.5
 
     def call(self, inputs):
         # Depending on quantizer mode (activation or weight) just clip inputs
@@ -669,7 +667,7 @@ class DoReFa(_BaseQuantizer):
         else:
             raise ValueError(
                 f"Invalid DoReFa quantizer mode {self.mode}. "
-                f"Valid values are 'activations' and 'weights'."
+                "Valid values are 'activations' and 'weights'."
             )
 
         @tf.custom_gradient

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -657,8 +657,7 @@ class DoReFaKernel(DoReFa):
 
     def call(self, inputs):
         
-        #tanh(0.) yields nan, but a limiter should yield 0.
-        limited = tf.where(inputs == 0., inputs, tf.math.tanh(inputs))
+        limited = tf.math.tanh(inputs)
         
         #Divider for max-value norm.
         #If all elements are 0., we would get a div by zero.

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -656,7 +656,6 @@ class DoReFaKernel(DoReFa):
     """
 
     def call(self, inputs):
-
         limited = tf.math.tanh(inputs)
 
         # Divider for max-value norm.

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -692,7 +692,6 @@ class DoReFaKernel(DoReFa):
 # `DoReFa` used to be called `DoReFaQuantizer`; this alias is for
 # backwards-compatibility.
 DoReFaQuantizer = DoReFa
-DoReFaKernelQuantizer = DoReFaKernel
 
 
 QuantizerType = Union[Quantizer, Callable[[tf.Tensor], tf.Tensor]]

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -582,7 +582,7 @@ class DoReFa(_BaseQuantizer):
     uses the same ranges as specified in the paper.
 
     The activation quantizer defines the function quantizek() from the paper with
-    the correct numeric range of [0, 1]. The kernel quantization mode adds
+    the correct numeric range of [0, 1]. The weight quantization mode adds
     pre- and post-processing for numeric range adaptions, soft limiting and
     norming. The full quantization function including the adaption of numeric ranges is
 
@@ -591,7 +591,7 @@ class DoReFa(_BaseQuantizer):
     \\]
 
     !!! warning
-        The kernel mode works for weights on the range [-1, 1], which matches the
+        The weight mode works for weights on the range [-1, 1], which matches the
         default setting of `constraints.weight_clip`. Do not use this quantizer
         with a different constraint `clip_value` than the default one.
 
@@ -601,7 +601,7 @@ class DoReFa(_BaseQuantizer):
 
     # Arguments
         k_bit: number of bits for the quantization.
-        mode: "activations" for clipping inputs on [0, 1] range or "kernel" for
+        mode: "activations" for clipping inputs on [0, 1] range or "weights" for
             soft-clipping and norming weights on [-1, 1] range before applying
             quantization.
         metrics: An array of metrics to add to the layer. If `None` the metrics set in
@@ -623,7 +623,7 @@ class DoReFa(_BaseQuantizer):
     def __init__(self, k_bit: int = 2, mode: str = "activations", **kwargs):
         self.precision = k_bit
 
-        if mode not in ("activations", "kernel"):
+        if mode not in ("activations", "weights"):
             raise ValueError(f"Invalid DoReFa quantizer mode {mode}.")
         self.mode = mode
 
@@ -661,7 +661,7 @@ class DoReFa(_BaseQuantizer):
         # on [0, 1] range or use weight preprocessing method.
         if self.mode == "activations":
             inputs = tf.clip_by_value(inputs, 0.0, 1.0)
-        elif self.mode == "kernel":
+        elif self.mode == "weights":
             inputs = self.weight_preprocess(inputs)
         else:
             raise ValueError(f"Invalid DoReFa quantizer mode {self.mode}.")
@@ -674,7 +674,7 @@ class DoReFa(_BaseQuantizer):
         outputs = _k_bit_with_identity_grad(inputs)
 
         # Scale weights from [0, 1] quantization range back to [-1,1] range
-        if self.mode == "kernel":
+        if self.mode == "weights":
             outputs = 2.0 * outputs - 1.0
 
         return super().call(outputs)

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -680,7 +680,7 @@ class DoReFa(_BaseQuantizer):
         return super().call(outputs)
 
     def get_config(self):
-        return {**super().get_config(), "k_bit": self.precision}
+        return {**super().get_config(), "k_bit": self.precision, "mode": self.mode}
 
 
 # `DoReFa` used to be called `DoReFaQuantizer`; this alias is for

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -602,30 +602,30 @@ class DoReFa(_BaseQuantizer):
 
     def get_config(self):
         return {**super().get_config(), "k_bit": self.precision}
-        
-        
+
+
 @utils.register_alias("dorefa_kernel_quantizer")
 @utils.register_keras_custom_object
 class DoReFaKernel(DoReFa):
     r"""Instantiates a serializable k_bit kernel quantizer as in the DoReFa paper.
-    
+
     This quantizer is the same like the `DoReFa` quantizer, but adds a preprocessing.
     Instead of limiting input operands (or in this case: weights) using a hard
     limiter, a tangens hyperbolicus is applied to achieve a softer limiting
     with a gradient, which is contineously differentiable itself.
-    
+
     \\[
     w_{lim}(w) = tanh(w)
     \\]
-    
+
     Furthermore, the weights of each layer are normed, such that the weight with
     the largest magnitude gets the largest or smallest (depending on its sign)
     quantizable value. That way, the full quantizable numeric range is utilized.
-    
+
     \\[
     w_{norm}(w) = \frac{w}{max(|w|)}
     \\]
-    
+
     The formulas can be found in the paper in section 2.3. Please note, that
     the paper refers to weights being quantized on a numeric range of [-1,1], while
     activations are quantized on the numeric range [0,1]. `DoReFa` defines the
@@ -635,11 +635,11 @@ class DoReFaKernel(DoReFa):
     The hard limiting inside `DoReFa` becomes ineffective, because its input
     is already limited by the hyperbolic tangent. The full quantization
     function including the adaption of numeric ranges is
-    
+
     \\[
     q(w) = 2quantize_{k}(\frac{w_{norm}\left(w_{lim}\left(w\right)\right)}{2} + \frac{1}{2}) - 1
     \\]
-    
+
     !!! warning
         This quantizer works for weights on the range [-1,1], which matches the
         default setting of `constraints.weight_clip`. Do not use this quantizer
@@ -648,7 +648,7 @@ class DoReFaKernel(DoReFa):
     ```plot-activation
     quantizers.DoReFaKernel
     ```
-    
+
     The interface of this quantizer is the same like the one of `DoReFa`.
 
     # References
@@ -657,35 +657,35 @@ class DoReFaKernel(DoReFa):
     """
 
     def call(self, inputs):
-        
+
         limited = tf.math.tanh(inputs)
-        
-        #Divider for max-value norm.
-        #If all elements are 0., we would get a div by zero.
-        #So when all elements are zero, nothing is normed. This is achieved by
-        #dividing by 1.
+
+        # Divider for max-value norm.
+        # If all elements are 0., we would get a div by zero.
+        # So when all elements are zero, nothing is normed. This is achieved by
+        # dividing by 1.
         dividend = tf.math.reduce_max(tf.math.abs(limited))
         dividend = tf.where(dividend == 0., tf.ones_like(dividend), dividend)
-        
-        #Need to stop the gradient here. Otherwise, for the maximum element,
-        #which gives the dividend, normed is limited/limited (for this one
-        #maximum digit). The derivative of y = x/x, dy/dx is just zero, when
-        #one does the simplification y = x/x = 1. But TF does NOT do this
-        #simplification when computing the gradient for the
-        #normed = limited/dividend operation. As a result, this gradient becomes
-        #complicated, because during the computation, "dividend" is not just a
-        #constant, but depends on "limited" instead. Here, tf.stop_gradient
-        #is used to mark "dividend" as a constant explicitly.
+
+        # Need to stop the gradient here. Otherwise, for the maximum element,
+        # which gives the dividend, normed is limited/limited (for this one
+        # maximum digit). The derivative of y = x/x, dy/dx is just zero, when
+        # one does the simplification y = x/x = 1. But TF does NOT do this
+        # simplification when computing the gradient for the
+        # normed = limited/dividend operation. As a result, this gradient
+        # becomes complicated, because during the computation, "dividend" is
+        # not just a constant, but depends on "limited" instead. Here,
+        # tf.stop_gradient is used to mark "dividend" as a constant explicitly.
         dividend = tf.stop_gradient(dividend)
-        
-        #Norm and scale from value range [-1,1] to [0,1]
+
+        # Norm and scale from value range [-1,1] to [0,1]
         normed = limited / dividend
         normed = (normed / 2.) + 0.5
-        
-        #Quantize and scale back to [-1,1] range
-        quantized =  super().call(normed)
+
+        # Quantize and scale back to [-1,1] range
+        quantized = super().call(normed)
         quantized = (2. * quantized) - 1.
-        
+
         return quantized
 
 

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -57,7 +57,6 @@ __all__ = [
     "DoReFa",
     "DoReFaQuantizer",
     "DoReFaKernel",
-    "DoReFaKernelQuantizer",
     "MagnitudeAwareSign",
     "NoOp",
     "NoOpQuantizer",

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -664,7 +664,7 @@ class DoReFaKernel(DoReFa):
         #If all elements are 0., we would get a div by zero.
         #So when all elements are zero, nothing is normed. This is achieved by
         #dividing by 1.
-        dividend = tf.reduce_max(tf.abs(limited))
+        dividend = tf.math.reduce_max(tf.math.abs(limited))
         dividend = tf.where(dividend == 0., tf.ones_like(dividend), dividend)
         
         #Need to stop the gradient here. Otherwise, for the maximum element,

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -611,7 +611,7 @@ class DoReFaKernel(DoReFa):
     This quantizer is the same like the `DoReFa` quantizer, but adds a preprocessing.
     Instead of limiting input operands (or in this case: weights) using a hard
     limiter, a tangens hyperbolicus is applied to achieve a softer limiting
-    with a gradient, which is contineously differentiable itself.
+    with a gradient, which is continuously differentiable itself.
 
     \\[
     w_{lim}(w) = \tanh(w)

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -612,7 +612,7 @@ class DoReFa(_BaseQuantizer):
         Quantization function
 
     # Raises
-        ValueError for bad value of *mode*.
+        ValueError for bad value of `mode`.
 
     # References
         - [DoReFa-Net: Training Low Bitwidth Convolutional Neural Networks with Low
@@ -625,7 +625,7 @@ class DoReFa(_BaseQuantizer):
 
         if mode not in ("activations", "kernel"):
             raise ValueError(f"Invalid DoReFa quantizer mode {mode}.")
-        self.mode = str(mode)
+        self.mode = mode
 
         super().__init__(**kwargs)
 

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -57,6 +57,7 @@ __all__ = [
     "DoReFa",
     "DoReFaQuantizer",
     "DoReFaKernel",
+    "DoReFaKernelQuantizer",
     "MagnitudeAwareSign",
     "NoOp",
     "NoOpQuantizer",

--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -624,8 +624,10 @@ class DoReFa(_BaseQuantizer):
         self.precision = k_bit
 
         if mode not in ("activations", "weights"):
-            raise ValueError(f"Invalid DoReFa quantizer mode {mode}. "
-                             f"Valid values are 'activations' and 'weights'.")
+            raise ValueError(
+                f"Invalid DoReFa quantizer mode {mode}. "
+                f"Valid values are 'activations' and 'weights'."
+            )
         self.mode = mode
 
         super().__init__(**kwargs)
@@ -665,8 +667,10 @@ class DoReFa(_BaseQuantizer):
         elif self.mode == "weights":
             inputs = self.weight_preprocess(inputs)
         else:
-            raise ValueError(f"Invalid DoReFa quantizer mode {self.mode}. "
-                             f"Valid values are 'activations' and 'weights'.")
+            raise ValueError(
+                f"Invalid DoReFa quantizer mode {self.mode}. "
+                f"Valid values are 'activations' and 'weights'."
+            )
 
         @tf.custom_gradient
         def _k_bit_with_identity_grad(x):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from packaging import version
+import functools
 
 import larq as lq
 from larq import testing_utils
@@ -388,6 +389,7 @@ class TestGradients:
         ("magnitude_aware_sign", lq.quantizers.MagnitudeAwareSign),
         ("ste_tern", lq.quantizers.SteTern),
         ("dorefa_quantizer", lq.quantizers.DoReFa),
+        ("dorefa_quantizer", functools.partial(lq.quantizers.DoReFa, mode="weights")),
     ],
 )
 def test_metrics(quantizer):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -237,7 +237,7 @@ class TestQuantization:
     @pytest.mark.parametrize("k_bit", [1, 2, 4, 6, 8])
     def test_dorefa_kernel_quantize(self, k_bit):
         x = tf.keras.backend.placeholder(ndim=2)
-        f = tf.keras.backend.function([x], [lq.quantizers.DoReFaKernel(k_bit)(x)])
+        f = tf.keras.backend.function([x], [lq.quantizers.DoReFa(k_bit, mode="kernel")(x)])
         real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         n = 2 ** k_bit - 1
@@ -385,7 +385,7 @@ class TestGradients:
         x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)
         with tf.GradientTape() as tape:
-            activation = lq.quantizers.DoReFaKernel(2)(tf_x)
+            activation = lq.quantizers.DoReFa(2, mode="kernel")(tf_x)
         grad = tape.gradient(activation, tf_x)
         np.testing.assert_allclose(grad.numpy(), tanh_grad(x))
 
@@ -400,7 +400,6 @@ class TestGradients:
         ("magnitude_aware_sign", lq.quantizers.MagnitudeAwareSign),
         ("ste_tern", lq.quantizers.SteTern),
         ("dorefa_quantizer", lq.quantizers.DoReFa),
-        ("dorefa_kernel_quantizer", lq.quantizers.DoReFaKernel),
     ],
 )
 def test_metrics(quantizer):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -412,4 +412,5 @@ def test_get_kernel_quantizer_accepts_function():
 
 def test_backwards_compat_aliases():
     assert lq.quantizers.DoReFaQuantizer == lq.quantizers.DoReFa
+    assert lq.quantizers.DoReFaKernelQuantizer == lq.quantizers.DoReFaKernel
     assert lq.quantizers.NoOpQuantizer == lq.quantizers.NoOp

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -462,5 +462,4 @@ def test_get_kernel_quantizer_accepts_function():
 
 def test_backwards_compat_aliases():
     assert lq.quantizers.DoReFaQuantizer == lq.quantizers.DoReFa
-    assert lq.quantizers.DoReFaKernelQuantizer == lq.quantizers.DoReFaKernel
     assert lq.quantizers.NoOpQuantizer == lq.quantizers.NoOp

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -217,14 +217,14 @@ class TestQuantization:
         assert not np.any(result < -1)
 
     @pytest.mark.parametrize("k_bit", [1, 2, 4, 6, 8])
-    @pytest.mark.parametrize("mode", ["activations", "kernel"])
+    @pytest.mark.parametrize("mode", ["activations", "weights"])
     def test_dorefa_quantize(self, k_bit, mode):
         x = tf.keras.backend.placeholder(ndim=2)
         f = tf.keras.backend.function([x], [lq.quantizers.DoReFa(k_bit, mode)(x)])
         real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
         n = 2 ** k_bit - 1
-        if mode == "kernel":
+        if mode == "weights":
             # Create the preprocessed and scaled stimulus, which is then ready to
             # go through the same test like for the activation quantizer
             divider = np.amax(np.abs(np.tanh(real_values)))
@@ -337,7 +337,7 @@ class TestGradients:
             grad.numpy(), np.where(abs(a) < 1, np.ones(a.shape) * scale_vector, 0)
         )
 
-    @pytest.mark.parametrize("mode", ["activations", "kernel"])
+    @pytest.mark.parametrize("mode", ["activations", "weights"])
     def test_dorefa_ste_grad(self, mode):
         @np.vectorize
         def ste_grad(x):
@@ -347,7 +347,7 @@ class TestGradients:
 
         # For other tests, the golden gradient is defined using python
         # expressions and "converted" to a numpy function using np.vectorize.
-        # But the kernel quantizer does a max-operation over the full
+        # But the weight quantizer does a max-operation over the full
         # quantized tensor, so np.vectorize, which causes the gradient to be
         # called element-wise, needs to be skipped!
         # @np.vectorize

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -1,8 +1,9 @@
+import functools
+
 import numpy as np
 import pytest
 import tensorflow as tf
 from packaging import version
-import functools
 
 import larq as lq
 from larq import testing_utils

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -66,6 +66,12 @@ class TestCommonFunctionality:
             lq.quantizers.get(42)
         with pytest.raises(ValueError):
             lq.quantizers.get("unknown")
+        with pytest.raises(ValueError):
+            lq.quantizers.DoReFa(k_bit=2, mode="unknown")
+        f = lq.quantizers.DoReFa(k_bit=2, mode="activations")
+        f.mode = "unknown"
+        with pytest.raises(ValueError):
+            f.call([0.])
 
     @pytest.mark.parametrize("quantizer", ["input_quantizer", "kernel_quantizer"])
     def test_layer_as_quantizer(self, quantizer, keras_should_run_eagerly):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -233,7 +233,7 @@ class TestQuantization:
                 ]
                 == i / n
             )
-            
+
     def test_dorefa_kernel_quantize(self):
         x = tf.keras.backend.placeholder(ndim=2)
         f = tf.keras.backend.function([x], [lq.quantizers.DoReFaKernel(2)(x)])
@@ -241,17 +241,17 @@ class TestQuantization:
         result = f([real_values])[0]
         k_bit = 2
         n = 2 ** k_bit - 1
-        #Create the preprocessed and scaled stimulus, which is then ready to
-        #go through the same test like for the DoReFa activation quantizer
+        # Create the preprocessed and scaled stimulus, which is then ready to
+        # go through the same test like for the DoReFa activation quantizer
         divider = np.amax(np.abs(np.tanh(real_values)))
         preprocessed = np.tanh(real_values) / divider
         preprocessed = (preprocessed / 2.) + 0.5
         assert not np.any(result > 1)
         assert not np.any(result < -1)
-        #In the assertion, the output scaling from [0,1] to [-1,1] now needs
-        #to be done here like in the weight quantizer when comparing digits
-        #of the quantized tensor to golden, quantized values. The golden,
-        #quantized value "i / n" is on the [0,1] range.
+        # In the assertion, the output scaling from [0,1] to [-1,1] now needs
+        # to be done here like in the weight quantizer when comparing digits
+        # of the quantized tensor to golden, quantized values. The golden,
+        # quantized value "i / n" is on the [0,1] range.
         for i in range(n + 1):
             np.testing.assert_allclose(
                 result[
@@ -365,19 +365,19 @@ class TestGradients:
             activation = lq.quantizers.DoReFa(2)(tf_x)
         grad = tape.gradient(activation, tf_x)
         np.testing.assert_allclose(grad.numpy(), ste_grad(x))
-		
+
     def test_dorefa_kernel_tanh_grad(self):
-        #For other tests, the golden gradient is defined using python
-        #expressions and "converted" to a numpy function using np.vectorize.
-        #But the kernel quantizer does a max-operation over the full
-        #quantized tensor, so np.vectorize, which causes the gradient to be
-        #called element-wise, needs to be skipped!
-        #@np.vectorize
+        # For other tests, the golden gradient is defined using python
+        # expressions and "converted" to a numpy function using np.vectorize.
+        # But the kernel quantizer does a max-operation over the full
+        # quantized tensor, so np.vectorize, which causes the gradient to be
+        # called element-wise, needs to be skipped!
+        # @np.vectorize
         def tanh_grad(x):
-            #1/(cosh**2) is the derivative of tanh. The gradients of the
-            #scaling operations cancel each other and the gradient of the
-            #quantizek function is supposed to be 1 everywhere, because it
-            #is used on its linear region only. tanh does all the limiting.
+            # 1/(cosh**2) is the derivative of tanh. The gradients of the
+            # scaling operations cancel each other and the gradient of the
+            # quantizek function is supposed to be 1 everywhere, because it
+            # is used on its linear region only. tanh does all the limiting.
             dividend = np.amax(np.abs(np.tanh(x)))
             return 1 / (np.cosh(x)**2.) / dividend
 

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -245,7 +245,7 @@ class TestQuantization:
         # go through the same test like for the DoReFa activation quantizer
         divider = np.amax(np.abs(np.tanh(real_values)))
         preprocessed = np.tanh(real_values) / divider
-        preprocessed = (preprocessed / 2.) + 0.5
+        preprocessed = (preprocessed / 2.0) + 0.5
         assert not np.any(result > 1)
         assert not np.any(result < -1)
         # In the assertion, the output scaling from [0,1] to [-1,1] now needs
@@ -258,7 +258,7 @@ class TestQuantization:
                     (preprocessed > (2 * i - 1) / (2 * n))
                     & (preprocessed < (2 * i + 1) / (2 * n))
                 ],
-                2 * (i / n) - 1.
+                2 * (i / n) - 1.0,
             )
 
 
@@ -379,7 +379,7 @@ class TestGradients:
             # quantizek function is supposed to be 1 everywhere, because it
             # is used on its linear region only. tanh does all the limiting.
             dividend = np.amax(np.abs(np.tanh(x)))
-            return 1 / (np.cosh(x)**2.) / dividend
+            return 1 / (np.cosh(x) ** 2.0) / dividend
 
         x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -353,12 +353,6 @@ class TestGradients:
                 return 1.0
             return 0.0
 
-        # For other tests, the golden gradient is defined using python
-        # expressions and "converted" to a numpy function using np.vectorize.
-        # But the weight quantizer does a max-operation over the full
-        # quantized tensor, so np.vectorize, which causes the gradient to be
-        # called element-wise, needs to be skipped!
-        # @np.vectorize
         def tanh_grad(x):
             # 1/(cosh**2) is the derivative of tanh. The gradients of the
             # scaling operations cancel each other and the gradient of the
@@ -367,10 +361,7 @@ class TestGradients:
             dividend = np.amax(np.abs(np.tanh(x)))
             return 1 / (np.cosh(x) ** 2.0) / dividend
 
-        if mode == "activations":
-            expected_gradient = ste_grad
-        else:
-            expected_gradient = tanh_grad
+        expected_gradient = ste_grad if mode == "activations" else tanh_grad
 
         x = testing_utils.generate_real_values_with_zeros(shape=(8, 3, 3, 16))
         tf_x = tf.Variable(x)

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -399,7 +399,7 @@ class TestGradients:
         ("magnitude_aware_sign", lq.quantizers.MagnitudeAwareSign),
         ("ste_tern", lq.quantizers.SteTern),
         ("dorefa_quantizer", lq.quantizers.DoReFa),
-		("dorefa_kernel_quantizer", lq.quantizers.DoReFaKernel),
+        ("dorefa_kernel_quantizer", lq.quantizers.DoReFaKernel),
     ],
 )
 def test_metrics(quantizer):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -234,12 +234,12 @@ class TestQuantization:
                 == i / n
             )
 
-    def test_dorefa_kernel_quantize(self):
+    @pytest.mark.parametrize("k_bit", [1, 2, 4, 6, 8])
+    def test_dorefa_kernel_quantize(self, k_bit):
         x = tf.keras.backend.placeholder(ndim=2)
-        f = tf.keras.backend.function([x], [lq.quantizers.DoReFaKernel(2)(x)])
+        f = tf.keras.backend.function([x], [lq.quantizers.DoReFaKernel(k_bit)(x)])
         real_values = testing_utils.generate_real_values_with_zeros()
         result = f([real_values])[0]
-        k_bit = 2
         n = 2 ** k_bit - 1
         # Create the preprocessed and scaled stimulus, which is then ready to
         # go through the same test like for the DoReFa activation quantizer
@@ -259,6 +259,7 @@ class TestQuantization:
                     & (preprocessed < (2 * i + 1) / (2 * n))
                 ],
                 2 * (i / n) - 1.0,
+                atol=1e-6,
             )
 
 

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -72,7 +72,7 @@ class TestCommonFunctionality:
         f = lq.quantizers.DoReFa(k_bit=2, mode="activations")
         f.mode = "unknown"
         with pytest.raises(ValueError):
-            f.call([0.])
+            f.call([0.0])
 
     @pytest.mark.parametrize("quantizer", ["input_quantizer", "kernel_quantizer"])
     def test_layer_as_quantizer(self, quantizer, keras_should_run_eagerly):
@@ -240,7 +240,7 @@ class TestQuantization:
             # The results, which are currently on [-1, 1] range get the same
             # scaling, so they behave like they were created on the activation
             # range and can be tested like that
-            result = result / 2. + 0.5
+            result = result / 2.0 + 0.5
         assert not np.any(result > 1)
         assert not np.any(result < 0)
         for i in range(n + 1):

--- a/larq/quantizers_test.py
+++ b/larq/quantizers_test.py
@@ -350,6 +350,7 @@ class TestGradients:
         ("magnitude_aware_sign", lq.quantizers.MagnitudeAwareSign),
         ("ste_tern", lq.quantizers.SteTern),
         ("dorefa_quantizer", lq.quantizers.DoReFa),
+		("dorefa_kernel_quantizer", lq.quantizers.DoReFaKernel),
     ],
 )
 def test_metrics(quantizer):


### PR DESCRIPTION
I mentioned in #620, that I use larq to implement a DoReFa weight quantizer I want to publish with this PR.

The code is added in quantizers.py together with an additional compat reference like it exists for the DoReFa activation quantizer. The new quantizer inherits from the activation quantizer, as it just adds preprocessing to the actual quantize step. In the [Paper](https://arxiv.org/pdf/1606.06160.pdf), section 2.3, one can see in formula (9), that the weight quantizer is defined by using the activation quantizer _quantizek_ together with limiting done with _tanh_ and some range-scaling operations.

I also added unit tests, which check the actual quantization and the gradient. The derivative of _tanh(x)_ is _1/cosh(x)**2_, which makes checking the gradient easy. The quantization can be checked by applying the desired preprocessing and then testing the preprocessed data just like the activation quantizer does. The tests pass.

Please check my docstring and review my comments. If I babble too much, delete the comments or tell me to do it. I could not built the docs, but I hope that my formulas look ok. I also don't know, wether saying
_The interface of this quantizer is the same like the one of DoReFa._
is ok for the docstring of if I should repeat the interface description of the DoReFa activation quantizer. And I don't know wether adding
```
plot-activation
quantizers.DoReFaKernel
```
to the docstring is ok and if the API doc quantizer figure is built automatically, but it fairly looks like it is.

And one last question: the activation quantizer is not included in _TestCommonFunctionality_, so I also did not include my own quantizer there. Is this ok?

Thank you for your time!