### PR TITLE
Add DoReFa plot for `mode="weights"`

### DIFF
--- a/larq/quantizers.py
+++ b/larq/quantizers.py
@@ -595,8 +595,14 @@ class DoReFa(_BaseQuantizer):
         default setting of `constraints.weight_clip`. Do not use this quantizer
         with a different constraint `clip_value` than the default one.
 
+    __`mode == "activations"`__
     ```plot-activation
     quantizers.DoReFa
+    ```
+
+    __`mode == "weights"`__
+    ```plot-activation
+    quantizers.DoReFa(mode='weights')
     ```
 
     # Arguments


### PR DESCRIPTION
This will show up in the docs like this:
![Screenshot 2021-05-05 at 11 10 15](https://user-images.githubusercontent.com/13285808/117126407-9ca7b880-ad92-11eb-94f2-2fd6796251a6.png)
