### PR TITLE
Properly pass `groups` and `dilation_rate` parameters to convolutional layers

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,6 +20,8 @@ jobs:
             python-version: 3.8
           - tf-version: 2.5.0
             python-version: 3.9
+          - tf-version: 2.6.0
+            python-version: 3.9
 
     steps:
       - uses: actions/checkout@v2

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -212,7 +212,9 @@ class QuantConv1D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv1D):
             if version.parse(tf.__version__) >= version.parse("2.3"):
                 kwargs = {**kwargs, "groups": groups}
             else:
-                raise ValueError("`groups` != 1 requires TensorFlow version 2.3 or newer.")
+                raise ValueError(
+                    "`groups` != 1 requires TensorFlow version 2.3 or newer."
+                )
         super().__init__(
             filters,
             kernel_size,
@@ -336,7 +338,9 @@ class QuantConv2D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv2D):
             if version.parse(tf.__version__) >= version.parse("2.3"):
                 kwargs = {**kwargs, "groups": groups}
             else:
-                raise ValueError("`groups` != 1 requires TensorFlow version 2.3 or newer.")
+                raise ValueError(
+                    "`groups` != 1 requires TensorFlow version 2.3 or newer."
+                )
         super().__init__(
             filters,
             kernel_size,
@@ -467,7 +471,9 @@ class QuantConv3D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv3D):
             if version.parse(tf.__version__) >= version.parse("2.3"):
                 kwargs = {**kwargs, "groups": groups}
             else:
-                raise ValueError("`groups` != 1 requires TensorFlow version 2.3 or newer.")
+                raise ValueError(
+                    "`groups` != 1 requires TensorFlow version 2.3 or newer."
+                )
         super().__init__(
             filters,
             kernel_size,

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -488,6 +488,11 @@ class QuantDepthwiseConv2D(
             It defaults to the `image_data_format` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be 'channels_last'.
+        dilation_rate: an integer or tuple/list of 2 integers, specifying the dilation
+            rate to use for dilated convolution. Can be a single integer to specify the
+            same value for all spatial dimensions. Currently, specifying any
+            `dilation_rate` value != 1 is incompatible with specifying any stride value
+            != 1.
         activation: Activation function to use.
             If you don't specify anything, no activation is applied (ie. `a(x) = x`).
         use_bias: Boolean, whether the layer uses a bias vector.
@@ -527,6 +532,7 @@ class QuantDepthwiseConv2D(
         pad_values=0.0,
         depth_multiplier=1,
         data_format=None,
+        dilation_rate=(1, 1),
         activation=None,
         use_bias=True,
         input_quantizer=None,
@@ -547,6 +553,7 @@ class QuantDepthwiseConv2D(
             pad_values=pad_values,
             depth_multiplier=depth_multiplier,
             data_format=data_format,
+            dilation_rate=dilation_rate,
             activation=activation,
             use_bias=use_bias,
             input_quantizer=input_quantizer,
@@ -1032,6 +1039,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
         padding="valid",
         output_padding=None,
         data_format=None,
+        dilation_rate=(1, 1, 1),
         activation=None,
         use_bias=True,
         input_quantizer=None,
@@ -1052,6 +1060,7 @@ class QuantConv3DTranspose(QuantizerBase, tf.keras.layers.Conv3DTranspose):
             padding=padding,
             output_padding=output_padding,
             data_format=data_format,
+            dilation_rate=dilation_rate,
             activation=activation,
             use_bias=use_bias,
             input_quantizer=input_quantizer,

--- a/larq/layers.py
+++ b/larq/layers.py
@@ -7,6 +7,7 @@ is equivalent to a full precision layer.
 """
 
 import tensorflow as tf
+from packaging import version
 
 from larq import utils
 from larq.layers_base import (
@@ -157,6 +158,11 @@ class QuantConv1D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv1D):
             dilation rate to use for dilated convolution. Currently, specifying any
             `dilation_rate` value != 1 is incompatible with specifying any `strides`
             value != 1.
+        groups: A positive integer specifying the number of groups in which the input
+            is split along the channel axis. Each group is convolved separately with
+            `filters / groups` filters. The output is the concatenation of all the
+            `groups` results along the channel axis. Input channels and `filters`
+            must both be divisible by `groups`.
         activation: Activation function to use. If you don't specify anything, no
             activation is applied (`a(x) = x`).
         use_bias: Boolean, whether the layer uses a bias vector.
@@ -188,6 +194,7 @@ class QuantConv1D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv1D):
         pad_values=0.0,
         data_format="channels_last",
         dilation_rate=1,
+        groups=1,
         activation=None,
         use_bias=True,
         input_quantizer=None,
@@ -201,6 +208,11 @@ class QuantConv1D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv1D):
         bias_constraint=None,
         **kwargs,
     ):
+        if groups != 1:
+            if version.parse(tf.__version__) >= version.parse("2.3"):
+                kwargs = {**kwargs, "groups": groups}
+            else:
+                raise ValueError("`groups` != 1 requires TensorFlow version 2.3 or newer.")
         super().__init__(
             filters,
             kernel_size,
@@ -264,6 +276,11 @@ class QuantConv2D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv2D):
             same value for all spatial dimensions. Currently, specifying any
             `dilation_rate` value != 1 is incompatible with specifying any stride value
             != 1.
+        groups: A positive integer specifying the number of groups in which the input
+            is split along the channel axis. Each group is convolved separately with
+            `filters / groups` filters. The output is the concatenation of all the
+            `groups` results along the channel axis. Input channels and `filters` must
+            both be divisible by `groups`.
         activation: Activation function to use. If you don't specify anything,
             no activation is applied (`a(x) = x`).
         use_bias: Boolean, whether the layer uses a bias vector.
@@ -301,6 +318,7 @@ class QuantConv2D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv2D):
         pad_values=0.0,
         data_format=None,
         dilation_rate=(1, 1),
+        groups=1,
         activation=None,
         use_bias=True,
         input_quantizer=None,
@@ -314,6 +332,11 @@ class QuantConv2D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv2D):
         bias_constraint=None,
         **kwargs,
     ):
+        if groups != 1:
+            if version.parse(tf.__version__) >= version.parse("2.3"):
+                kwargs = {**kwargs, "groups": groups}
+            else:
+                raise ValueError("`groups` != 1 requires TensorFlow version 2.3 or newer.")
         super().__init__(
             filters,
             kernel_size,
@@ -379,6 +402,11 @@ class QuantConv3D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv3D):
             same value for all spatial dimensions. Currently, specifying any
             `dilation_rate` value != 1 is incompatible with specifying any stride value
             != 1.
+        groups: A positive integer specifying the number of groups in which the input
+            is split along the channel axis. Each group is convolved separately with
+            `filters / groups` filters. The output is the concatenation of all the
+            `groups` results along the channel axis. Input channels and `filters` must
+            both be divisible by `groups`.
         activation: Activation function to use. If you don't specify anything,
             no activation is applied (`a(x) = x`).
         use_bias: Boolean, whether the layer uses a bias vector.
@@ -421,6 +449,7 @@ class QuantConv3D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv3D):
         pad_values=0.0,
         data_format=None,
         dilation_rate=(1, 1, 1),
+        groups=1,
         activation=None,
         use_bias=True,
         input_quantizer=None,
@@ -434,6 +463,11 @@ class QuantConv3D(QuantizerBase, QuantizerBaseConv, tf.keras.layers.Conv3D):
         bias_constraint=None,
         **kwargs,
     ):
+        if groups != 1:
+            if version.parse(tf.__version__) >= version.parse("2.3"):
+                kwargs = {**kwargs, "groups": groups}
+            else:
+                raise ValueError("`groups` != 1 requires TensorFlow version 2.3 or newer.")
         super().__init__(
             filters,
             kernel_size,

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -281,16 +281,15 @@ class TestLayerWarns:
         with pytest.raises(ValueError, match=r".*pad_values.*"):
             lq.layers.QuantConv1D(24, 3, padding="causal", pad_values=1.0)
 
-    @pytest.mark.skipif(
-        version.parse(tf.__version__) >= version.parse("2.3"),
-        reason="Only raise error for old TF versions.",
-    )
     @pytest.mark.parametrize(
         "layer", [lq.layers.QuantConv1D, lq.layers.QuantConv2D, lq.layers.QuantConv3D]
     )
-    def test_unsupported_groups(self, layer):
-        with pytest.raises(ValueError, match=r".*groups.*"):
-            layer(24, 3, groups=2)
+    def test_groups(self, layer):
+        if version.parse(tf.__version__) < version.parse("2.3"):
+            with pytest.raises(ValueError, match=r".*groups.*"):
+                layer(24, 3, groups=2)
+        else:
+            assert layer(24, 3, groups=2).groups == 2
 
 
 @pytest.mark.parametrize(

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -3,6 +3,7 @@ import inspect
 import numpy as np
 import pytest
 import tensorflow as tf
+from packaging import version
 
 import larq as lq
 from larq import testing_utils
@@ -279,6 +280,17 @@ class TestLayerWarns:
     def test_conv1d_non_zero_padding_raises(self):
         with pytest.raises(ValueError, match=r".*pad_values.*"):
             lq.layers.QuantConv1D(24, 3, padding="causal", pad_values=1.0)
+
+    @pytest.mark.skipif(
+        version.parse(tf.__version__) >= version.parse("2.3"),
+        reason="Only raise error for old TF versions.",
+    )
+    @pytest.mark.parametrize(
+        "layer", [lq.layers.QuantConv1D, lq.layers.QuantConv2D, lq.layers.QuantConv3D]
+    )
+    def test_unsupported_groups(self, layer):
+        with pytest.raises(ValueError, match=r".*groups.*"):
+            layer(24, 3, groups=2)
 
 
 @pytest.mark.parametrize(

--- a/larq/layers_test.py
+++ b/larq/layers_test.py
@@ -314,13 +314,19 @@ def test_layer_kwargs(quant_layer, layer):
     quant_params_list = list(quant_params.keys())
     params_list = list(params.keys())
 
-    for p in (
+    ignored_params = [
         "input_quantizer",
         "kernel_quantizer",
         "depthwise_quantizer",
         "pointwise_quantizer",
         "pad_values",
-    ):
+    ]
+    if version.parse(tf.__version__) < version.parse("2.3"):
+        ignored_params.append("groups")
+        if layer in (tf.keras.layers.DepthwiseConv2D, tf.keras.layers.Conv3DTranspose):
+            ignored_params.append("dilation_rate")
+
+    for p in ignored_params:
         try:
             quant_params_list.remove(p)
         except ValueError:


### PR DESCRIPTION
This PR doesn't add any functionality since the parameters were already handled via `kwargs`, but it makes sure that our unittests pass and improves the documentation of our layers.

I am not sure why this only made our CI fail very recently, but so I added TF 2.6 and Python 3.9 to our CI matrix as well, just to be save.

This pulls in https://github.com/tensorflow/tensorflow/commit/5f2e159a58d1ef3414b2c34339266449574d8f94 and https://github.com/tensorflow/tensorflow/commit/46c79db67db33d7a14e124fc0b5cf23e0910d039