### PR TITLE
Prevent `CaseOptimizer` from creating unused vars

### DIFF
--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -148,7 +148,7 @@ class CaseOptimizer(tf.keras.optimizers.Optimizer):
             _ = self.iterations
             # This is only necessary in TF 2.0 and older, but doesn't hurt on newer versions
             for optimizer, opt_grads_and_vars in zip(self.optimizers, grad_var_lists):
-                optimizer._create_slots([v for (_, v) in grads_and_vars])
+                optimizer._create_slots([v for (_, v) in opt_grads_and_vars])
 
         return tf.distribute.get_replica_context().merge_call(
             self._apply_gradients, args=(grad_var_lists, name), kwargs=kwargs

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -155,13 +155,15 @@ class TestCaseOptimizer:
             loss="sparse_categorical_crossentropy",
             optimizer=lq.optimizers.CaseOptimizer(
                 (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
-                default_optimizer=tf.keras.optimizers.Adam(0.01),
+                default_optimizer=tf.keras.optimizers.SGD(0.1, momentum=0.9),
             ),
         )
         model.fit(train_images[:1], train_labels[:1], epochs=1)
 
         opt_weights = model.optimizer.weights
-        assert len(opt_weights) != 0
+        # SGD with momentum and Bop both create a single momentum variable per weight
+        # and one variable each to keep track of iterations
+        assert len(opt_weights) == len(model.weights) + 2
         checked_weights = 0
         for opt in model.optimizer.optimizers:
             for weight in opt.weights:


### PR DESCRIPTION
This PR fixes a typo which caused the `CaseOptimizer` to create unnecessary slot variables for weights it isn't assign to optimise.