### PR TITLE
Support TensorFlow 2.11

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.14.0, 1.15.5, 2.0.4, 2.1.4, 2.2.3, 2.3.4, 2.4.4, 2.5.3, 2.6.5, 2.7.3, 2.8.2, 2.9.1, 2.10.0, 2.11.0rc1]
+        tf-version: [1.14.0, 1.15.5, 2.0.4, 2.1.4, 2.2.3, 2.3.4, 2.4.4, 2.5.3, 2.6.5, 2.7.3, 2.8.2, 2.9.1, 2.10.0, 2.11.0rc2]
         python-version: [3.7]
         include:
           - tf-version: 2.4.4
@@ -30,7 +30,7 @@ jobs:
             python-version: "3.10"
           - tf-version: 2.10.0
             python-version: "3.10"
-          - tf-version: 2.11.0rc1
+          - tf-version: 2.11.0rc2
             python-version: "3.10"
 
     steps:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.14.0, 1.15.5, 2.0.4, 2.1.4, 2.2.3, 2.3.4, 2.4.4, 2.5.3, 2.6.5, 2.7.3, 2.8.2, 2.9.1, 2.10.0]
+        tf-version: [1.14.0, 1.15.5, 2.0.4, 2.1.4, 2.2.3, 2.3.4, 2.4.4, 2.5.3, 2.6.5, 2.7.3, 2.8.2, 2.9.1, 2.10.0, 2.11.0rc1]
         python-version: [3.7]
         include:
           - tf-version: 2.4.4
@@ -29,6 +29,8 @@ jobs:
           - tf-version: 2.9.1
             python-version: "3.10"
           - tf-version: 2.10.0
+            python-version: "3.10"
+          - tf-version: 2.11.0rc1
             python-version: "3.10"
 
     steps:

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -9,6 +9,11 @@ import larq as lq
 from larq import testing_utils as lq_testing_utils
 from larq.callbacks import HyperparameterScheduler
 
+try:
+    from tensorflow.keras.optimizers import legacy as optimizers
+except ImportError:
+    from tensorflow.keras import optimizers
+
 
 class TestHyperparameterScheduler:
     def _create_data_and_model(self, train_samples=1000):
@@ -112,7 +117,7 @@ class TestHyperparameterScheduler:
         x_train, y_train, model = self._create_data_and_model()
 
         bop = lq.optimizers.Bop(threshold=1e-6, gamma=1e-3)
-        adam = tf.keras.optimizers.Adam(0.01)
+        adam = optimizers.Adam(0.01)
         case_optimizer = lq.optimizers.CaseOptimizer(
             (lq.optimizers.Bop.is_binary_variable, bop),
             default_optimizer=adam,

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -10,7 +10,7 @@ import larq as lq
 from larq import testing_utils as lq_testing_utils
 from larq.callbacks import HyperparameterScheduler
 
-if version.parse(tf.__version__) >= version.parse("2.11.0rc0")
+if version.parse(tf.__version__) >= version.parse("2.11.0rc0"):
     from tensorflow.keras.optimizers import legacy as optimizers
 else:
     from tensorflow.keras import optimizers

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -3,15 +3,16 @@ import math
 import numpy as np
 import pytest
 import tensorflow as tf
+from packaging import version
 from tensorflow.python.keras import testing_utils
 
 import larq as lq
 from larq import testing_utils as lq_testing_utils
 from larq.callbacks import HyperparameterScheduler
 
-try:
+if version.parse(tf.__version__) >= version.parse("2.11.0rc0")
     from tensorflow.keras.optimizers import legacy as optimizers
-except ImportError:
+else:
     from tensorflow.keras import optimizers
 
 

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -39,15 +39,16 @@ from copy import deepcopy
 from typing import Callable, Optional, Tuple
 
 import tensorflow as tf
+from packaging import version
 
 import larq as lq
 from larq import utils
 
 __all__ = ["Bop", "CaseOptimizer"]
 
-try:
+if version.parse(tf.__version__) >= version.parse("2.11.0rc0"):
     from tensorflow.keras.optimizers.legacy import Optimizer
-except ImportError:
+else:
     from tensorflow.keras.optimizers import Optimizer
 
 

--- a/larq/optimizers.py
+++ b/larq/optimizers.py
@@ -47,9 +47,9 @@ from larq import utils
 __all__ = ["Bop", "CaseOptimizer"]
 
 if version.parse(tf.__version__) >= version.parse("2.11.0rc0"):
-    from tensorflow.keras.optimizers.legacy import Optimizer
+    from tensorflow.keras.optimizers.legacy import Optimizer  # type: ignore
 else:
-    from tensorflow.keras.optimizers import Optimizer
+    from tensorflow.keras.optimizers import Optimizer  # type: ignore
 
 
 # From https://github.com/keras-team/keras/blob/a8606fd45b760cce3e65727e9d62cae796c45930/keras/optimizer_v2/optimizer_v2.py#L1430-L1450

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -7,6 +7,11 @@ from tensorflow.python.keras import testing_utils
 import larq as lq
 from larq import testing_utils as lq_testing_utils
 
+try:
+    from tensorflow.keras.optimizers import legacy as optimizers
+except ImportError:
+    from tensorflow.keras import optimizers
+
 
 def _test_optimizer(
     optimizer, target=0.75, test_kernels_are_binary=True, trainable_bn=True
@@ -112,7 +117,7 @@ class TestCaseOptimizer:
         with pytest.raises(ValueError):
             naughty_case_opt = lq.optimizers.CaseOptimizer(
                 (lambda var: False, lq.optimizers.Bop()),
-                default_optimizer=tf.keras.optimizers.Adam(0.01),
+                default_optimizer=optimizers.Adam(0.01),
             )
 
             # Simple MNIST model
@@ -152,7 +157,7 @@ class TestCaseOptimizer:
             loss="sparse_categorical_crossentropy",
             optimizer=lq.optimizers.CaseOptimizer(
                 (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
-                default_optimizer=tf.keras.optimizers.SGD(0.1, momentum=0.9),
+                default_optimizer=optimizers.SGD(0.1, momentum=0.9),
             ),
         )
         model.fit(train_images[:1], train_labels[:1], epochs=1)
@@ -172,7 +177,7 @@ class TestCaseOptimizer:
     def test_checkpoint(self, tmp_path):
         # Build and run a simple model.
         var = tf.Variable([2.0])
-        opt = tf.keras.optimizers.SGD(1.0, momentum=1.0)
+        opt = optimizers.SGD(1.0, momentum=1.0)
         opt = lq.optimizers.CaseOptimizer((lambda var: True, opt))
         opt.minimize(lambda: var + 1.0, var_list=[var])
         slot_var = opt.optimizers[0].get_slot(var, "momentum")
@@ -198,7 +203,7 @@ class TestBopOptimizer:
         _test_optimizer(
             lq.optimizers.CaseOptimizer(
                 (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
-                default_optimizer=tf.keras.optimizers.Adam(0.01),
+                default_optimizer=optimizers.Adam(0.01),
             ),
             test_kernels_are_binary=True,
         )
@@ -206,7 +211,7 @@ class TestBopOptimizer:
         _test_optimizer(
             lq.optimizers.CaseOptimizer(
                 (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
-                default_optimizer=tf.keras.optimizers.Adam(0.01),
+                default_optimizer=optimizers.Adam(0.01),
             ),
             test_kernels_are_binary=True,
             trainable_bn=False,
@@ -217,7 +222,7 @@ class TestBopOptimizer:
     def test_mixed_precision(self):
         opt = lq.optimizers.CaseOptimizer(
             (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
-            default_optimizer=tf.keras.optimizers.Adam(0.01),
+            default_optimizer=optimizers.Adam(0.01),
         )
         try:
             opt = tf.keras.mixed_precision.LossScaleOptimizer(opt)
@@ -241,7 +246,7 @@ class TestBopOptimizer:
                         ),
                     ),
                 ),
-                default_optimizer=tf.keras.optimizers.Adam(0.01),
+                default_optimizer=optimizers.Adam(0.01),
             ),
             test_kernels_are_binary=True,
         )
@@ -250,7 +255,7 @@ class TestBopOptimizer:
         _test_serialization(
             lq.optimizers.CaseOptimizer(
                 (lq.optimizers.Bop.is_binary_variable, lq.optimizers.Bop()),
-                default_optimizer=tf.keras.optimizers.Adam(0.01),
+                default_optimizer=optimizers.Adam(0.01),
             ),
         )
 

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -1,15 +1,16 @@
 import numpy as np
 import pytest
 import tensorflow as tf
+from packaging import version
 from tensorflow import keras
 from tensorflow.python.keras import testing_utils
 
 import larq as lq
 from larq import testing_utils as lq_testing_utils
 
-try:
+if version.parse(tf.__version__) >= version.parse("2.11.0rc0"):
     from tensorflow.keras.optimizers import legacy as optimizers
-except ImportError:
+else:
     from tensorflow.keras import optimizers
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,12 @@ setup(
         "terminaltables>=3.1.0",
         "dataclasses ; python_version<'3.7'",
         "importlib-metadata >= 2.0, < 4.0 ; python_version<'3.8'",
+        "packaging>=19.2",
     ],
     extras_require={
         "tensorflow": ["tensorflow>=1.14.0"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.14.0"],
         "test": [
-            "packaging>=19.2,<22.0",
             "pytest>=5.2.4,<7.3.0",
             "pytest-cov>=2.8.1,<4.1.0",
             "pytest-xdist>=1.30,<3.1",


### PR DESCRIPTION
In TF 2.11 `tf.keras.optimizers.Optimizer` now points to the new Keras optimizer, and old optimizers have moved to the `tf.keras.optimizers.legacy` namespace. Since our custom optimizers are not compatible with the new optimizers yet, this PR explicitely uses the legacy optimizers.