### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Flake8
         run: flake8
       - name: Black code style
-        run: black --check --target-version py36 --exclude 'build/|\.mypy_cache/|\.venv/|env/|larq/snapshots/|.pytype/' .
+        run: black --check --target-version py37 --exclude 'build/|\.mypy_cache/|\.venv/|env/|larq/snapshots/|.pytype/' .
       - name: Check import order with isort
         run: isort . --check --diff
       - name: Type check with PyType

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -15,8 +15,6 @@ jobs:
         python-version: [3.7]
         include:
           - tf-version: 2.4.4
-            python-version: 3.6
-          - tf-version: 2.4.4
             python-version: 3.8
           - tf-version: 2.5.3
             python-version: 3.9

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Check out our examples on how to train a Binarized Neural Network in just a few 
 
 Before installing Larq, please install:
 
-- [Python](https://www.python.org/) version `3.6`, `3.7`, `3.8`, `3.9`, or `3.10`
+- [Python](https://www.python.org/) version `3.7`, `3.8`, `3.9`, or `3.10`
 - [Tensorflow](https://www.tensorflow.org/install) version `1.14`, `1.15`, `2.0`, `2.1`, `2.2`, `2.3`, `2.4`, `2.5`, `2.6`, `2.7`, `2.8`, `2.9`, or `2.10`:
   ```shell
   pip install tensorflow  # or tensorflow-gpu

--- a/larq/callbacks_test.py
+++ b/larq/callbacks_test.py
@@ -11,9 +11,9 @@ from larq import testing_utils as lq_testing_utils
 from larq.callbacks import HyperparameterScheduler
 
 if version.parse(tf.__version__) >= version.parse("2.11.0rc0"):
-    from tensorflow.keras.optimizers import legacy as optimizers
+    from tensorflow.keras.optimizers import legacy as optimizers  # type: ignore
 else:
-    from tensorflow.keras import optimizers
+    from tensorflow.keras import optimizers  # type: ignore
 
 
 class TestHyperparameterScheduler:

--- a/larq/optimizers_test.py
+++ b/larq/optimizers_test.py
@@ -9,9 +9,9 @@ import larq as lq
 from larq import testing_utils as lq_testing_utils
 
 if version.parse(tf.__version__) >= version.parse("2.11.0rc0"):
-    from tensorflow.keras.optimizers import legacy as optimizers
+    from tensorflow.keras.optimizers import legacy as optimizers  # type: ignore
 else:
-    from tensorflow.keras import optimizers
+    from tensorflow.keras import optimizers  # type: ignore
 
 
 def _test_optimizer(

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import find_packages, setup
 
 
 def readme():
-    with open("README.md", "r") as f:
+    with open("README.md") as f:
         return f.read()
 
 
 setup(
     name="larq",
     version="0.12.2",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     author="Plumerai",
     author_email="opensource@plumerai.com",
     description="An Open Source Machine Learning Library for Training Binarized Neural Networks",
@@ -21,7 +21,6 @@ setup(
     install_requires=[
         "numpy >= 1.15.4, < 2.0",
         "terminaltables>=3.1.0",
-        "dataclasses ; python_version<'3.7'",
         "importlib-metadata >= 2.0, < 4.0 ; python_version<'3.8'",
         "packaging>=19.2",
     ],
@@ -50,7 +49,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Python 3.6 is [EOL since 23 Dec 2021](https://endoflife.date/python). I think it is save to drop support for it in larq at this point.