### PR TITLE
Support TensorFlow 2.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.9
       - name: Install project dependencies
         run: |
-          pip install tensorflow-cpu==2.11.1
+          pip install tensorflow-cpu==2.12.0
           pip install -e .[lint,test]
       - name: Run Flake8
         run: flake8

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,6 +30,10 @@ jobs:
             python-version: "3.10"
           - tf-version: 2.11.1
             python-version: "3.10"
+          - tf-version: 2.12.0
+            python-version: "3.8"
+          - tf-version: 2.12.0
+            python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -339,6 +339,15 @@ class QuantizedVariable(tf.Variable, TensorType):
         obj_map[self] = obj_map[self.latent_variable]
         return obj_map, resource_map
 
+    def _export_to_saved_model_graph(self, object_map, tensor_map, options, **kwargs):
+        # By delegating this method to the wrapped variable, SavedModel with
+        # QuantizedVariables are identical to SavedModel with normal variables.
+        resource_list = self.latent_variable._export_to_saved_model_graph(
+            object_map, tensor_map, options, **kwargs
+        )
+        object_map[self] = object_map[self.latent_variable]
+        return resource_list
+
     # TODO: Maybe encode the fact the variable is an QuantizedVariable in to_proto().
     def to_proto(self, *args, **kwargs):
         return self.latent_variable.to_proto(*args, **kwargs)


### PR DESCRIPTION
This adds TF 2.12 to the CI test matrix and applies https://github.com/keras-team/keras/commit/93245cb096b94bc57a71f517a1a08a3dde5da9e2 to fix our model saving tests.