### PR TITLE
Add `QuantizedVariableSpec` to `QuantizedVariable`

### DIFF
--- a/larq/quantized_variable.py
+++ b/larq/quantized_variable.py
@@ -22,10 +22,14 @@ except ModuleNotFoundError:
 
 UNSPECIFIED = object()
 
-_SUPPORTS_TRACE_TYPE = version.parse(tf.__version__) >= version.parse("2.9")
+_SUPPORTS_TRACE_TYPE = version.parse(tf.__version__) >= version.parse("2.8")
 if _SUPPORTS_TRACE_TYPE:
+    try:
+        from tensorflow.types.experimental import TraceType
+    except ImportError:
+        from tensorflow.python.types.trace import TraceType
 
-    class QuantizedVariableSpec(tf.types.experimental.TraceType):
+    class QuantizedVariableSpec(TraceType):
         """TraceType for QuantizedVariableSpec for tracing with tf.function.
         This class implements the Type for QuantizedVariable used in tracing.
         """

--- a/larq/quantized_variable_test.py
+++ b/larq/quantized_variable_test.py
@@ -279,6 +279,18 @@ def test_tf_function_control_dependencies(quantized):
     assert_almost_equal(evaluate(x), 4.0 if quantized else 2.0)
 
 
+def test_tf_function_with_variable_and_quantized_variable():
+    variable = get_var(tf.ones(2, 2))
+    quantized_variable = QuantizedVariable.from_variable(variable)
+
+    @tf.function
+    def f(x):
+        return x + 1
+
+    f(variable)
+    f(quantized_variable)
+
+
 @pytest.mark.usefixtures("eager_and_graph_mode")
 def test_checkpoint(tmp_path):
     x = QuantizedVariable.from_variable(get_var(0.0), quantizer=lambda x: 2 * x)


### PR DESCRIPTION
This adds a trace type to our quantized variable according to https://github.com/keras-team/keras/commit/ed99e34f279a2d2d6a44af87ee64f8fc98c7e8b9

This fixes an issue I am seeing on single GPU with optimizers that use `jit_compile=True`.